### PR TITLE
Fix hb_atomic_ptr_cmpexch -Wunused-value warnings

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -345,7 +345,7 @@ hb_language_get_default (void)
   hb_language_t language = (hb_language_t) hb_atomic_ptr_get (&default_language);
   if (unlikely (language == HB_LANGUAGE_INVALID)) {
     language = hb_language_from_string (setlocale (LC_CTYPE, NULL), -1);
-    hb_atomic_ptr_cmpexch (&default_language, HB_LANGUAGE_INVALID, language);
+    (void) hb_atomic_ptr_cmpexch (&default_language, HB_LANGUAGE_INVALID, language);
   }
 
   return default_language;

--- a/src/hb-icu.cc
+++ b/src/hb-icu.cc
@@ -363,10 +363,8 @@ hb_icu_get_unicode_funcs (void)
   if (!hb_atomic_ptr_get (&normalizer)) {
     UErrorCode icu_err = U_ZERO_ERROR;
     /* We ignore failure in getNFCInstace(). */
-    hb_atomic_ptr_cmpexch (&normalizer, NULL, unorm2_getNFCInstance (&icu_err));
+    (void) hb_atomic_ptr_cmpexch (&normalizer, NULL, unorm2_getNFCInstance (&icu_err));
   }
 #endif
   return const_cast<hb_unicode_funcs_t *> (&_hb_icu_unicode_funcs);
 }
-
-


### PR DESCRIPTION
When building Firefox's in-tree copy of harfbuzz, the following clang warning is reported for the (nonatomic!) implementation of `hb_atomic_ptr_cmpexch()` used in the Firefox OS simulator builds for OS X:

```
gfx/harfbuzz/src/hb-common.cc:348:5: warning: expression result unused [-Wunused-value]
```