### PR TITLE
Add #ifdef HB_USE_ATEXIT to fix -Wunused-function warnings

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -235,7 +235,7 @@ struct hb_language_item_t {
 static hb_language_item_t *langs;
 
 #ifdef HB_USE_ATEXIT
-static inline
+static
 void free_langs (void)
 {
   while (langs) {

--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -467,11 +467,13 @@ hb_ft_font_create_referenced (FT_Face ft_face)
 
 static FT_Library ft_library;
 
-static inline
+#ifdef HB_USE_ATEXIT
+static
 void free_ft_library (void)
 {
   FT_Done_FreeType (ft_library);
 }
+#endif
 
 static FT_Library
 get_ft_library (void)

--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -279,11 +279,13 @@ hb_feature_to_string (hb_feature_t *feature,
 
 static const char **static_shaper_list;
 
-static inline
+#ifdef HB_USE_ATEXIT
+static
 void free_static_shaper_list (void)
 {
   free (static_shaper_list);
 }
+#endif
 
 /**
  * hb_shape_list_shapers:

--- a/src/hb-shaper.cc
+++ b/src/hb-shaper.cc
@@ -40,12 +40,14 @@ static const hb_shaper_pair_t all_shapers[] = {
 
 static const hb_shaper_pair_t *static_shapers;
 
-static inline
+#ifdef HB_USE_ATEXIT
+static
 void free_static_shapers (void)
 {
   if (unlikely (static_shapers != all_shapers))
     free ((void *) static_shapers);
 }
+#endif
 
 const hb_shaper_pair_t *
 _hb_shapers_get (void)


### PR DESCRIPTION
Commit e9171af55cc6a402eb20db4ea74c86a0b1e70e85 marked some functions as static inline to suppress -Wunused-function warnings, but this inline trick doesn't always suppress the warnings. Plus, inline doesn't make sense for function pointers passed to `atexit()`. Instead, this PR wraps these functions in `#ifdef HB_USE_ATEXIT` because they are only called by `atexit()` `#ifdef HB_USE_ATEXIT`.

This change will fix some warnings when building Firefox's in-tree copy of Harfbuzz:
```
gfx/harfbuzz/src/hb-shape.cc:283:6 [-Wunused-function] unused function 'free_static_shaper_list'
gfx/harfbuzz/src/hb-shaper.cc:44:6 [-Wunused-function] unused function 'free_static_shapers'
```