### PR TITLE
Change New Tai Lue shaping engine from SEA to default

### DIFF
--- a/src/hb-ot-shape-complex-private.hh
+++ b/src/hb-ot-shape-complex-private.hh
@@ -259,6 +259,7 @@ hb_ot_shape_complex_categorize (const hb_ot_shape_planner_t *planner)
 
     /* Unicode-4.1 additions */
     case HB_SCRIPT_KHAROSHTHI:
+    case HB_SCRIPT_NEW_TAI_LUE:
     case HB_SCRIPT_SYLOTI_NAGRI:
 
     /* Unicode-5.1 additions */
@@ -339,7 +340,6 @@ hb_ot_shape_complex_categorize (const hb_ot_shape_planner_t *planner)
 
     /* Unicode-4.1 additions */
     case HB_SCRIPT_BUGINESE:
-    case HB_SCRIPT_NEW_TAI_LUE:
 
     /* Unicode-5.1 additions */
     case HB_SCRIPT_CHAM:


### PR DESCRIPTION
This is to reflect the UTC decision to change the encoding model of
New Tai Lue from logical to visual to be similar to Thai, Lao, and
Tai Viet: http://www.unicode.org/L2/L2014/14250.htm#141-C26

The visual encoding is already the current practice of encoding New
Tai Lue on the web anyway:
http://www.unicode.org/L2/L2014/14195-newtailue.txt

Fixes behdad/harfbuzz#66.