### PR TITLE
Improve hb-shape/hb-view's help text w.r.t. output options 

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -459,7 +459,7 @@ output_options_t::add_options (option_parser_t *parser)
   };
   parser->add_group (entries,
 		     "output",
-		     "Output detination & format options (refer to --help-output-content for content options):",
+		     "Output detination & format options:",
 		     "Options controlling the destination and form of the output",
 		     this);
 }

--- a/util/options.cc
+++ b/util/options.cc
@@ -699,10 +699,10 @@ format_options_t::add_options (option_parser_t *parser)
     {"show-text", 0, 0, G_OPTION_ARG_NONE, &this->show_text, "Prefix each line of output with its corresponding input text", NULL},
     {"show-unicode", 0, 0, G_OPTION_ARG_NONE, &this->show_unicode, "Prefix each line of output with its corresponding input codepoint(s)", NULL},
     {"show-line-num", 0, 0, G_OPTION_ARG_NONE, &this->show_line_num, "Prefix each line of output with its corresponding input line number", NULL},
-    {"verbose", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &parse_verbose, "Prefix each line of output with each of the above", NULL},
+    {"verbose", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &parse_verbose, "Prefix each line of output with all of the above", NULL},
     {"no-glyph-names", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &this->show_glyph_names, "Output glyph indices instead of names", NULL},
     {"no-positions", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &this->show_positions, "Do not output glyph positions", NULL},
-    {"no-clusters",	0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &this->show_clusters, "Do not output cluster indices", NULL},
+    {"no-clusters", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &this->show_clusters, "Do not output cluster indices", NULL},
     {NULL}
   };
   parser->add_group (entries,

--- a/util/options.cc
+++ b/util/options.cc
@@ -444,9 +444,7 @@ output_options_t::add_options (option_parser_t *parser)
   else
   {
     char *items = g_strjoinv ("/", const_cast<char **> (supported_formats));
-    text = g_strdup_printf ("Set output serialization format\n\n    Supported output formats are: %s\n%s", items,
-      "      text: [<glyph name or index>=<glyph cluster index within input>@<horizontal displacement>,<vertical displacement>+<horizontal advance>,<vertical advance>|...]\n"
-      "      json: [{\"g\": <glyph name or index>, \"ax\": <horizontal advance>, \"ay\": <vertical advance>, \"dx\": <horizontal displacement>, \"dy\": <vertical displacement>, \"cl\": <glyph cluster index within input>}, ...]");
+    text = g_strdup_printf ("Set output format\n\n    Supported output formats are: %s", items);
     g_free (items);
     parser->free_later ((char *) text);
   }
@@ -459,7 +457,7 @@ output_options_t::add_options (option_parser_t *parser)
   };
   parser->add_group (entries,
 		     "output",
-		     "Output detination & format options:",
+		     "Output destination & format options:",
 		     "Options controlling the destination and form of the output",
 		     this);
 }
@@ -706,9 +704,12 @@ format_options_t::add_options (option_parser_t *parser)
     {NULL}
   };
   parser->add_group (entries,
-		     "output-content",
-		     "Output content options (refer to --help-output for output syntax):",
-		     "Options controlling the content of the output",
+		     "output-syntax",
+		     "Output syntax:\n"
+         "    text: [<glyph name or index>=<glyph cluster index within input>@<horizontal displacement>,<vertical displacement>+<horizontal advance>,<vertical advance>|...]\n"
+         "    json: [{\"g\": <glyph name or index>, \"ax\": <horizontal advance>, \"ay\": <vertical advance>, \"dx\": <horizontal displacement>, \"dy\": <vertical displacement>, \"cl\": <glyph cluster index within input>}, ...]\n"
+         "\nOutput syntax options:",
+		     "Options controlling the syntax of the output",
 		     this);
 }
 

--- a/util/options.cc
+++ b/util/options.cc
@@ -440,11 +440,13 @@ output_options_t::add_options (option_parser_t *parser)
   const char *text;
 
   if (NULL == supported_formats)
-    text = "Set output format";
+    text = "Set output serialization format";
   else
   {
     char *items = g_strjoinv ("/", const_cast<char **> (supported_formats));
-    text = g_strdup_printf ("Set output format\n\n    Supported output formats are: %s", items);
+    text = g_strdup_printf ("Set output serialization format\n\n    Supported output formats are: %s\n%s", items,
+      "      text: [<glyph name or index>=<glyph cluster index within input>@<horizontal displacement>,<vertical displacement>+<horizontal advance>,<vertical advance>|...]\n"
+      "      json: [{\"g\": <glyph name or index>, \"ax\": <horizontal advance>, \"ay\": <vertical advance>, \"dx\": <horizontal displacement>, \"dy\": <vertical displacement>, \"cl\": <glyph cluster index within input>}, ...]");
     g_free (items);
     parser->free_later ((char *) text);
   }
@@ -457,8 +459,8 @@ output_options_t::add_options (option_parser_t *parser)
   };
   parser->add_group (entries,
 		     "output",
-		     "Output options:",
-		     "Options controlling the output",
+		     "Output detination & format options (refer to --help-output-content for content options):",
+		     "Options controlling the destination and form of the output",
 		     this);
 }
 
@@ -694,19 +696,19 @@ format_options_t::add_options (option_parser_t *parser)
 {
   GOptionEntry entries[] =
   {
-    {"no-glyph-names",	0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,	&this->show_glyph_names,	"Use glyph indices instead of names",	NULL},
-    {"no-positions",	0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,	&this->show_positions,		"Do not show glyph positions",		NULL},
-    {"no-clusters",	0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,	&this->show_clusters,		"Do not show cluster mapping",		NULL},
-    {"show-text",	0, 0,			  G_OPTION_ARG_NONE,	&this->show_text,		"Show input text",			NULL},
-    {"show-unicode",	0, 0,			  G_OPTION_ARG_NONE,	&this->show_unicode,		"Show input Unicode codepoints",	NULL},
-    {"show-line-num",	0, 0,			  G_OPTION_ARG_NONE,	&this->show_line_num,		"Show line numbers",			NULL},
-    {"verbose",		0, G_OPTION_FLAG_NO_ARG,  G_OPTION_ARG_CALLBACK,(gpointer) &parse_verbose,	"Show everything",			NULL},
+    {"show-text", 0, 0, G_OPTION_ARG_NONE, &this->show_text, "Prefix each line of output with its corresponding input text", NULL},
+    {"show-unicode", 0, 0, G_OPTION_ARG_NONE, &this->show_unicode, "Prefix each line of output with its corresponding input codepoint(s)", NULL},
+    {"show-line-num", 0, 0, G_OPTION_ARG_NONE, &this->show_line_num, "Prefix each line of output with its corresponding input line number", NULL},
+    {"verbose", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &parse_verbose, "Prefix each line of output with each of the above", NULL},
+    {"no-glyph-names", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &this->show_glyph_names, "Output glyph indices instead of names", NULL},
+    {"no-positions", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &this->show_positions, "Do not output glyph positions", NULL},
+    {"no-clusters",	0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &this->show_clusters, "Do not output cluster indices", NULL},
     {NULL}
   };
   parser->add_group (entries,
-		     "format",
-		     "Format options:",
-		     "Options controlling the formatting of buffer contents",
+		     "output-content",
+		     "Output content options (refer to --help-output for output syntax):",
+		     "Options controlling the content of the output",
 		     this);
 }
 


### PR DESCRIPTION
Maybe the format and options are self-evident if you know enough about typography - but I certainly didn't when I got started.

New `--help-output`:

	Output destination & format options:
	  --output-file=filename                Set output file-name (default: stdout)
	  --output-format=format                Set output format

	    Supported output formats are: ansi/png/svg/pdf/ps/eps

New `--help-output-syntax` (renamed from `--help-format` since otherwise we have too many definitions of the word "format"):

    Output syntax:
	    text: [<glyph name or index>=<glyph cluster index within input>@<horizontal displacement>,<vertical displacement>+<horizontal advance>,<vertical advance>|...]
	    json: [{"g": <glyph name or index>, "ax": <horizontal advance>, "ay": <vertical advance>, "dx": <horizontal displacement>, "dy": <vertical displacement>, "cl": <glyph cluster index within input>}, ...]

	Output syntax options:
	  --show-text                           Prefix each line of output with its corresponding input text
	  --show-unicode                        Prefix each line of output with its corresponding input codepoint(s)
	  --show-line-num                       Prefix each line of output with its corresponding input line number
	  --verbose                             Prefix each line of output with all of the above
	  --no-glyph-names                      Output glyph indices instead of names
	  --no-positions                        Do not output glyph positions
	  --no-clusters                         Do not output cluster indices

It'd be nice to merge these two help sections, but that looks like it's quite involved - would be good to do at the same time as https://github.com/behdad/harfbuzz/issues/78.