### PR TITLE
[bindings] Fix *_from_string functions

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -57,7 +57,7 @@ _hb_options_init (void)
 
 /**
  * hb_tag_from_string:
- * @str: (array length=len): 
+ * @str: (array length=len) (element-type uint8_t): 
  * @len: 
  *
  * 
@@ -115,7 +115,7 @@ const char direction_strings[][4] = {
 
 /**
  * hb_direction_from_string:
- * @str: (array length=len): 
+ * @str: (array length=len) (element-type uint8_t): 
  * @len: 
  *
  * 
@@ -281,7 +281,7 @@ retry:
 
 /**
  * hb_language_from_string:
- * @str: (array length=len): 
+ * @str: (array length=len) (element-type uint8_t): 
  * @len: 
  *
  * 
@@ -401,7 +401,7 @@ hb_script_from_iso15924_tag (hb_tag_t tag)
 
 /**
  * hb_script_from_string:
- * @s: (array length=len): 
+ * @s: (array length=len) (element-type uint8_t): 
  * @len: 
  *
  * 

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -814,7 +814,7 @@ hb_font_glyph_to_string (hb_font_t *font,
 /**
  * hb_font_glyph_from_string:
  * @font: a font.
- * @s: (array length=len): 
+ * @s: (array length=len) (element-type uint8_t): 
  * @len: 
  * @glyph: (out): 
  *

--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -198,7 +198,7 @@ parse_one_feature (const char **pp, const char *end, hb_feature_t *feature)
 
 /**
  * hb_feature_from_string:
- * @str: (array length=len):
+ * @str: (array length=len) (element-type uint8_t):
  * @len: 
  * @feature: (out) (optional):
  *


### PR DESCRIPTION
Without the element-type they will be getting garbage, at least with
Python.