### PR TITLE
Fix unary minus operator applied to unsigned int

### DIFF
--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -220,7 +220,7 @@ hb_ot_get_glyph_v_advance (hb_font_t *font HB_UNUSED,
 			   void *user_data HB_UNUSED)
 {
   const hb_ot_font_t *ot_font = (const hb_ot_font_t *) font_data;
-  return font->em_scale_y (-ot_font->v_metrics.get_advance (glyph));
+  return font->em_scale_y (-static_cast<int>(ot_font->v_metrics.get_advance (glyph)));
 }
 
 static hb_bool_t


### PR DESCRIPTION
Applying unary minus operator to unsigned int causes the following warning on MSVS:
  warning C4146: unary minus operator applied to unsigned type, result still unsigned

This patch fixes the warning.