### PR TITLE
fix static linking with icu-uc

### DIFF
--- a/test/api/Makefile.am
+++ b/test/api/Makefile.am
@@ -34,7 +34,7 @@ test_unicode_CPPFLAGS += $(GLIB_CFLAGS)
 endif
 if HAVE_ICU
 test_unicode_CPPFLAGS += $(ICU_CFLAGS)
-test_unicode_LDADD += $(top_builddir)/src/libharfbuzz-icu.la
+test_unicode_LDADD += $(top_builddir)/src/libharfbuzz-icu.la $(ICU_LIBS)
 endif
 
 


### PR DESCRIPTION
When linking test-unicode statically it needs $(ICU_LIBS)
which contains all required flags.
Especially -lstdc++.

Fixes:
http://autobuild.buildroot.net/results/210/2107f9dfb39eeb6559fb4271c7af8b39aef521ca/

Signed-off-by: Romain Naour <romain.naour@openwide.fr>