### PR TITLE
Use gtk-doc to build user's manual as well as reference

### DIFF
--- a/docs/reference/harfbuzz-docs.xml
+++ b/docs/reference/harfbuzz-docs.xml
@@ -6,7 +6,7 @@
 ]>
 <book id="index">
   <bookinfo>
-    <title>HarfBuzz Reference Manual</title>
+    <title>HarfBuzz Manual</title>
     <releaseinfo>
       for HarfBuzz &version;.
       <!--The latest version of this documentation can be found on-line at
@@ -14,52 +14,65 @@
     </releaseinfo>
   </bookinfo>
 
-  <chapter>
-    <title>[Insert title here]</title>
-    <xi:include href="xml/hb.xml"/>
-    <xi:include href="xml/hb-common.xml"/>
-    <xi:include href="xml/hb-unicode.xml"/>
-    <xi:include href="xml/hb-buffer.xml"/>
-    <xi:include href="xml/hb-blob.xml"/>
-    <xi:include href="xml/hb-face.xml"/>
-    <xi:include href="xml/hb-font.xml"/>
-    <xi:include href="xml/hb-shape.xml"/>
+  <part>
+    <title>User's manual</title>
+      <xi:include href="../usermanual-ch01.xml"/>
+      <xi:include href="../usermanual-ch02.xml"/>
+      <xi:include href="../usermanual-ch03.xml"/>
+      <xi:include href="../usermanual-ch04.xml"/>
+      <xi:include href="../usermanual-ch05.xml"/>
+      <xi:include href="../usermanual-ch06.xml"/>
+  </part>
 
-    <xi:include href="xml/hb-version.xml"/>
-    <xi:include href="xml/hb-deprecated.xml"/>
+  <part>
+    <title>Reference manual</title>
+      <chapter>
+        <title>Harfbuzz API</title>
+        <xi:include href="xml/hb.xml"/>
+        <xi:include href="xml/hb-common.xml"/>
+        <xi:include href="xml/hb-unicode.xml"/>
+        <xi:include href="xml/hb-buffer.xml"/>
+        <xi:include href="xml/hb-blob.xml"/>
+        <xi:include href="xml/hb-face.xml"/>
+        <xi:include href="xml/hb-font.xml"/>
+        <xi:include href="xml/hb-shape.xml"/>
 
-    <xi:include href="xml/hb-set.xml"/>
+        <xi:include href="xml/hb-version.xml"/>
+        <xi:include href="xml/hb-deprecated.xml"/>
 
-    <xi:include href="xml/hb-ot.xml"/>
-    <xi:include href="xml/hb-ot-layout.xml"/>
-    <xi:include href="xml/hb-ot-tag.xml"/>
+        <xi:include href="xml/hb-set.xml"/>
 
-    <xi:include href="xml/hb-shape-plan.xml"/>
+        <xi:include href="xml/hb-ot.xml"/>
+        <xi:include href="xml/hb-ot-layout.xml"/>
+        <xi:include href="xml/hb-ot-tag.xml"/>
 
-    <xi:include href="xml/hb-glib.xml"/>
-    <xi:include href="xml/hb-icu.xml"/>
+        <xi:include href="xml/hb-shape-plan.xml"/>
 
-    <xi:include href="xml/hb-ft.xml"/>
+        <xi:include href="xml/hb-glib.xml"/>
+        <xi:include href="xml/hb-icu.xml"/>
 
-    <xi:include href="xml/hb-graphite2.xml"/>
-    <xi:include href="xml/hb-uniscribe.xml"/>
-    <xi:include href="xml/hb-coretext.xml"/>
+        <xi:include href="xml/hb-ft.xml"/>
 
-    <xi:include href="xml/hb-gobject.xml"/>
+        <xi:include href="xml/hb-graphite2.xml"/>
+        <xi:include href="xml/hb-uniscribe.xml"/>
+        <xi:include href="xml/hb-coretext.xml"/>
 
-  </chapter>
-  <chapter id="object-tree">
-    <title>Object Hierarchy</title>
-     <xi:include href="xml/tree_index.sgml"/>
-  </chapter>
-  <index id="api-index-full">
-    <title>API Index</title>
-    <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
-  </index>
-  <index id="deprecated-api-index" role="deprecated">
-    <title>Index of deprecated API</title>
-    <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
-  </index>
+        <xi:include href="xml/hb-gobject.xml"/>
 
-  <xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>
+      </chapter>
+      <chapter id="object-tree">
+        <title>Object Hierarchy</title>
+         <xi:include href="xml/tree_index.sgml"/>
+      </chapter>
+      <index id="api-index-full">
+        <title>API Index</title>
+        <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
+      </index>
+      <index id="deprecated-api-index" role="deprecated">
+        <title>Index of deprecated API</title>
+        <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
+      </index>
+
+      <xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>
+  </part>
 </book>

--- a/docs/usermanual-ch01.xml
+++ b/docs/usermanual-ch01.xml
@@ -1,11 +1,11 @@
-<sect1 id="what-is-harfbuzz">
+<chapter id="what-is-harfbuzz">
   <title>What is Harfbuzz?</title>
   <para>
     Harfbuzz is a <emphasis>text shaping engine</emphasis>. It solves
     the problem of selecting and positioning glyphs from a font given a
     Unicode string.
   </para>
-  <sect2 id="why-do-i-need-it">
+  <section id="why-do-i-need-it">
     <title>Why do I need it?</title>
     <para>
       Text shaping is an integral part of preparing text for display. It
@@ -99,8 +99,8 @@
       rest of this manual, we are going to assume that you are the
       implementor of a text layout engine.
     </para>
-  </sect2>
-  <sect2 id="why-is-it-called-harfbuzz">
+  </section>
+  <section id="why-is-it-called-harfbuzz">
     <title>Why is it called Harfbuzz?</title>
     <para>
       Harfbuzz began its life as text shaping code within the FreeType
@@ -111,5 +111,5 @@
       engine for OpenType fonts - &quot;Harfbuzz&quot; is the Persian
       for &quot;open type&quot;.
     </para>
-  </sect2>
-</sect1>
+  </section>
+</chapter>

--- a/docs/usermanual-ch02.xml
+++ b/docs/usermanual-ch02.xml
@@ -131,6 +131,7 @@ ABC אבג DEF
           bidi algorithm to it. Libraries such as ICU and fribidi can do
           this for you.
         </para>
+      </listitem>
       <listitem>
         <para>
           Harfbuzz won't help you with text that contains different font

--- a/docs/usermanual-ch02.xml
+++ b/docs/usermanual-ch02.xml
@@ -1,4 +1,4 @@
-<sect1 id="hello-harfbuzz">
+<chapter id="hello-harfbuzz">
   <title>Hello, Harfbuzz</title>
   <para>
     Here's the simplest Harfbuzz that can possibly work. We will improve
@@ -90,7 +90,7 @@
   hb_buffer_destroy(buf);
   hb_font_destroy(hb_ft_font);
 </programlisting>
-  <sect2 id="what-harfbuzz-doesnt-do">
+  <section id="what-harfbuzz-doesnt-do">
     <title>What Harfbuzz doesn't do</title>
     <para>
       The code above will take a UTF8 string, shape it, and give you the
@@ -179,5 +179,5 @@ ABC אבג DEF
       Harfbuzz's API to refine that example and improve our text shaping
       capabilities.
     </para>
-  </sect2>
-</sect1>
+  </section>
+</chapter>

--- a/docs/usermanual-ch03.xml
+++ b/docs/usermanual-ch03.xml
@@ -1,4 +1,4 @@
-<sect1 id="buffers-language-script-and-direction">
+<chapter id="buffers-language-script-and-direction">
   <title>Buffers, language, script and direction</title>
   <para>
     The input to Harfbuzz is a series of Unicode characters, stored in a
@@ -6,7 +6,7 @@
     the text that we want and then customize the properties of the
     buffer.
   </para>
-  <sect2 id="creating-and-destroying-buffers">
+  <section id="creating-and-destroying-buffers">
     <title>Creating and destroying buffers</title>
     <para>
       As we saw in our initial example, a buffer is created and
@@ -49,8 +49,8 @@ void somefunc(hb_buffer_t *buffer) {
       throw away the string in the buffer but keep the options, you can
       instead call <literal>hb_buffer_clear_contents(buffer)</literal>.
     </para>
-  </sect2>
-  <sect2 id="adding-text-to-the-buffer">
+  </section>
+  <section id="adding-text-to-the-buffer">
     <title>Adding text to the buffer</title>
     <para>
       Now we have a brand new Harfbuzz buffer. Let's start filling it
@@ -58,20 +58,20 @@ void somefunc(hb_buffer_t *buffer) {
       of Unicode codepoints, but your input string is probably in one of
       the standard Unicode character encodings (UTF-8, UTF-16, UTF-3 )
     </para>
-  </sect2>
-  <sect2 id="setting-buffer-properties">
+  </section>
+  <section id="setting-buffer-properties">
     <title>Setting buffer properties</title>
     <para>
     </para>
-  </sect2>
-  <sect2 id="what-about-the-other-scripts">
+  </section>
+  <section id="what-about-the-other-scripts">
     <title>What about the other scripts?</title>
     <para>
     </para>
-  </sect2>
-  <sect2 id="customizing-unicode-functions">
+  </section>
+  <section id="customizing-unicode-functions">
     <title>Customizing Unicode functions</title>
     <para>
     </para>
-  </sect2>
-</sect1>
+  </section>
+</chapter>

--- a/docs/usermanual-ch04.xml
+++ b/docs/usermanual-ch04.xml
@@ -1,18 +1,18 @@
-<sect1 id="fonts-and-faces">
+<chapter id="fonts-and-faces">
   <title>Fonts and faces</title>
-  <sect2 id="using-freetype">
+  <section id="using-freetype">
     <title>Using FreeType</title>
     <para>
     </para>
-  </sect2>
-  <sect2 id="using-harfbuzzs-native-opentype-implementation">
+  </section>
+  <section id="using-harfbuzzs-native-opentype-implementation">
     <title>Using Harfbuzz's native OpenType implementation</title>
     <para>
     </para>
-  </sect2>
-  <sect2 id="using-your-own-font-functions">
+  </section>
+  <section id="using-your-own-font-functions">
     <title>Using your own font functions</title>
     <para>
     </para>
-  </sect2>
-</sect1>
+  </section>
+</chapter>

--- a/docs/usermanual-ch05.xml
+++ b/docs/usermanual-ch05.xml
@@ -1,13 +1,13 @@
-<sect1 id="shaping-and-shape-plans">
+<chapter id="shaping-and-shape-plans">
   <title>Shaping and shape plans</title>
-  <sect2 id="opentype-features">
+  <section id="opentype-features">
     <title>OpenType features</title>
     <para>
     </para>
-  </sect2>
-  <sect2 id="plans-and-caching">
+  </section>
+  <section id="plans-and-caching">
     <title>Plans and caching</title>
     <para>
     </para>
-  </sect2>
-</sect1>
+  </section>
+</chapter>


### PR DESCRIPTION
This adds the chapters of user's manual into the main Docbook document processed by gtk-doc. Running "make" on the docs will now create one HTML/PDF file with two parts: the first part is the user manual and the second part is the API reference.