### PR TITLE
Update the sources so they will compile under Visual Studio

### DIFF
--- a/src/hb-buffer-private.hh
+++ b/src/hb-buffer-private.hh
@@ -48,8 +48,8 @@
 ASSERT_STATIC (sizeof (hb_glyph_info_t) == 20);
 ASSERT_STATIC (sizeof (hb_glyph_info_t) == sizeof (hb_glyph_position_t));
 
-template <> class hb_mark_as_flags_t<hb_buffer_flags_t> {};
-template <> class hb_mark_as_flags_t<hb_buffer_serialize_flags_t> {};
+HB_MARK_AS_FLAG_T (hb_buffer_flags_t);
+HB_MARK_AS_FLAG_T (hb_buffer_serialize_flags_t);
 
 enum hb_buffer_scratch_flags_t {
   HB_BUFFER_SCRATCH_FLAG_DEFAULT			= 0x00000000u,
@@ -64,7 +64,7 @@ enum hb_buffer_scratch_flags_t {
   HB_BUFFER_SCRATCH_FLAG_COMPLEX2			= 0x04000000u,
   HB_BUFFER_SCRATCH_FLAG_COMPLEX3			= 0x08000000u,
 };
-template <> class hb_mark_as_flags_t<hb_buffer_scratch_flags_t> {};
+HB_MARK_AS_FLAG_T (hb_buffer_scratch_flags_t);
 
 
 /*

--- a/src/hb-ot-layout-common-private.hh
+++ b/src/hb-ot-layout-common-private.hh
@@ -581,7 +581,7 @@ struct LookupFlag : USHORT
 
 } /* namespace OT */
 /* This has to be outside the namespace. */
-template <> class hb_mark_as_flags_t<OT::LookupFlag::Flags> {};
+HB_MARK_AS_FLAG_T (OT::LookupFlag::Flags);
 namespace OT {
 
 struct Lookup

--- a/src/hb-ot-layout-private.hh
+++ b/src/hb-ot-layout-private.hh
@@ -65,7 +65,7 @@ enum hb_ot_layout_glyph_props_flags_t
 					  HB_OT_LAYOUT_GLYPH_PROPS_LIGATED |
 					  HB_OT_LAYOUT_GLYPH_PROPS_MULTIPLIED
 };
-template <> class hb_mark_as_flags_t<hb_ot_layout_glyph_props_flags_t> {};
+HB_MARK_AS_FLAG_T (hb_ot_layout_glyph_props_flags_t);
 
 
 /*
@@ -237,7 +237,7 @@ enum hb_unicode_props_flags_t {
   UPROPS_MASK_IGNORABLE = 0x80u,
   UPROPS_MASK_GEN_CAT   = 0x1Fu
 };
-template <> class hb_mark_as_flags_t<hb_unicode_props_flags_t> {};
+HB_MARK_AS_FLAG_T (hb_unicode_props_flags_t);
 
 static inline void
 _hb_glyph_info_set_unicode_props (hb_glyph_info_t *info, hb_buffer_t *buffer)

--- a/src/hb-ot-map-private.hh
+++ b/src/hb-ot-map-private.hh
@@ -159,7 +159,7 @@ enum hb_ot_map_feature_flags_t {
   F_MANUAL_ZWJ		= 0x0004u, /* Don't skip over ZWJ when matching. */
   F_GLOBAL_SEARCH	= 0x0008u  /* If feature not found in LangSys, look for it in global feature list and pick one. */
 };
-template <> class hb_mark_as_flags_t<hb_ot_map_feature_flags_t> {};
+HB_MARK_AS_FLAG_T (hb_ot_map_feature_flags_t);
 /* Macro version for where const is desired. */
 #define F_COMBINE(l,r) (hb_ot_map_feature_flags_t ((unsigned int) (l) | (unsigned int) (r)))
 

--- a/src/hb-ot-shape-complex-arabic.cc
+++ b/src/hb-ot-shape-complex-arabic.cc
@@ -469,8 +469,9 @@ apply_stch (const hb_ot_shape_plan_t *plan,
   DEBUG_MSG (ARABIC, NULL, "overlap for stretching is %d", overlap);
   int sign = font->x_scale < 0 ? -1 : +1;
   unsigned int extra_glyphs_needed = 0; // Set during MEASURE, used during CUT
+  typedef enum { MEASURE, CUT } step_t;
 
-  for (enum step_t { MEASURE, CUT } step = MEASURE; step <= CUT; step = (step_t) (step + 1))
+  for (step_t step = MEASURE; step <= CUT; step = (step_t) (step + 1))
   {
     unsigned int count = buffer->len;
     hb_glyph_info_t *info = buffer->info;

--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -119,6 +119,15 @@ extern "C" void  hb_free_impl(void *ptr);
 #define HB_FUNC __func__
 #endif
 
+/* Use templates for bitwise ops on enums or MSVC's DEFINE_ENUM_FLAG_OPERATORS */
+#ifdef _MSC_VER
+# pragma warning(disable:4200)
+# pragma warning(disable:4800)
+# define HB_MARK_AS_FLAG_T(flags_t)	DEFINE_ENUM_FLAG_OPERATORS (##flags_t##);
+#else
+# define HB_MARK_AS_FLAG_T(flags_t)	template <> class hb_mark_as_flags_t<flags_t> {};
+#endif
+
 /*
  * Borrowed from https://bugzilla.mozilla.org/show_bug.cgi?id=1215411
  * HB_FALLTHROUGH is an annotation to suppress compiler warnings about switch
@@ -895,6 +904,7 @@ hb_in_ranges (T u, T lo1, T hi1, T lo2, T hi2, T lo3, T hi3)
 /* To my surprise, looks like the function resolver is happy to silently cast
  * one enum to another...  So this doesn't provide the type-checking that I
  * originally had in mind... :( */
+#ifndef _MSC_VER
 template <class T> class hb_mark_as_flags_t;
 template <class T> static inline T operator | (T l, T r)
 { hb_mark_as_flags_t<T> unused HB_UNUSED; return T ((unsigned int) l | (unsigned int) r); }
@@ -906,6 +916,7 @@ template <class T> static inline T& operator |= (T &l, T r)
 { hb_mark_as_flags_t<T> unused HB_UNUSED; l = l | r; return l; }
 template <class T> static inline T& operator &= (T& l, T r)
 { hb_mark_as_flags_t<T> unused HB_UNUSED; l = l & r; return l; }
+#endif
 
 
 /* Useful for set-operations on small enums.

--- a/util/ansi-print.cc
+++ b/util/ansi-print.cc
@@ -41,7 +41,7 @@
 #include <unistd.h> /* for isatty() */
 #endif
 
-#ifdef _MSC_VER
+#if defined (_MSC_VER) && (_MSC_VER < 1800)
 static inline long int
 lround (double x)
 {
@@ -51,6 +51,8 @@ lround (double x)
     return ceil (x - 0.5);
 }
 #endif
+
+#define ESC_E (char)27
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))
 
@@ -298,7 +300,7 @@ block_best (const biimage_t &bi, bool *inverse)
     }
     if (best_s < score) {
       static const char *lower[7] = {"▁", "▂", "▃", "▄", "▅", "▆", "▇"};
-      unsigned int which = lround (((best_i + 1) * 8) / bi.height);
+      unsigned int which = lround ((double) ((best_i + 1) * 8) / bi.height);
       if (1 <= which && which <= 7) {
 	score = best_s;
 	*inverse = best_inv;
@@ -330,7 +332,7 @@ block_best (const biimage_t &bi, bool *inverse)
     }
     if (best_s < score) {
       static const char *left [7] = {"▏", "▎", "▍", "▌", "▋", "▊", "▉"};
-      unsigned int which = lround (((best_i + 1) * 8) / bi.width);
+      unsigned int which = lround ((double) ((best_i + 1) * 8) / bi.width);
       if (1 <= which && which <= 7) {
 	score = best_s;
 	*inverse = best_inv;
@@ -395,7 +397,7 @@ ansi_print_image_rgb24 (const uint32_t *data,
       bi.set (cell);
       if (bi.unicolor) {
         if (last_bg != bi.bg) {
-	  printf ("\e[%dm", 40 + bi.bg);
+	  printf ("%c[%dm", ESC_E, 40 + bi.bg);
 	  last_bg = bi.bg;
 	}
 	printf (" ");
@@ -405,13 +407,13 @@ ansi_print_image_rgb24 (const uint32_t *data,
         const char *c = block_best (bi, &inverse);
 	if (inverse) {
 	  if (last_bg != bi.fg || last_fg != bi.bg) {
-	    printf ("\e[%d;%dm", 30 + bi.bg, 40 + bi.fg);
+	    printf ("%c[%d;%dm", ESC_E, 30 + bi.bg, 40 + bi.fg);
 	    last_bg = bi.fg;
 	    last_fg = bi.bg;
 	  }
 	} else {
 	  if (last_bg != bi.bg || last_fg != bi.fg) {
-	    printf ("\e[%d;%dm", 40 + bi.bg, 30 + bi.fg);
+	    printf ("%c[%d;%dm", ESC_E, 40 + bi.bg, 30 + bi.fg);
 	    last_bg = bi.bg;
 	    last_fg = bi.fg;
 	  }
@@ -419,7 +421,7 @@ ansi_print_image_rgb24 (const uint32_t *data,
 	printf ("%s", c);
       }
     }
-    printf ("\e[0m\n"); /* Reset */
+    printf ("%c[0m\n", ESC_E); /* Reset */
     last_bg = last_fg = -1;
   }
 }

--- a/util/helper-cairo.cc
+++ b/util/helper-cairo.cc
@@ -341,25 +341,25 @@ helper_cairo_create_context (double w, double h,
   }
   if (0)
     ;
-    else if (0 == strcasecmp (extension, "ansi"))
+    else if (0 == g_ascii_strcasecmp (extension, "ansi"))
       constructor2 = _cairo_ansi_surface_create_for_stream;
   #ifdef CAIRO_HAS_PNG_FUNCTIONS
-    else if (0 == strcasecmp (extension, "png"))
+    else if (0 == g_ascii_strcasecmp (extension, "png"))
       constructor2 = _cairo_png_surface_create_for_stream;
   #endif
   #ifdef CAIRO_HAS_SVG_SURFACE
-    else if (0 == strcasecmp (extension, "svg"))
+    else if (0 == g_ascii_strcasecmp (extension, "svg"))
       constructor = cairo_svg_surface_create_for_stream;
   #endif
   #ifdef CAIRO_HAS_PDF_SURFACE
-    else if (0 == strcasecmp (extension, "pdf"))
+    else if (0 == g_ascii_strcasecmp (extension, "pdf"))
       constructor = cairo_pdf_surface_create_for_stream;
   #endif
   #ifdef CAIRO_HAS_PS_SURFACE
-    else if (0 == strcasecmp (extension, "ps"))
+    else if (0 == g_ascii_strcasecmp (extension, "ps"))
       constructor = cairo_ps_surface_create_for_stream;
    #ifdef HAS_EPS
-    else if (0 == strcasecmp (extension, "eps"))
+    else if (0 == g_ascii_strcasecmp (extension, "eps"))
       constructor = _cairo_eps_surface_create_for_stream;
    #endif
   #endif
@@ -478,16 +478,16 @@ helper_cairo_line_from_buffer (helper_cairo_line_t *l,
   for (i = 0; i < (int) l->num_glyphs; i++)
   {
     l->glyphs[i].index = hb_glyph[i].codepoint;
-    l->glyphs[i].x = scalbn ( hb_position->x_offset + x, scale_bits);
-    l->glyphs[i].y = scalbn (-hb_position->y_offset + y, scale_bits);
+    l->glyphs[i].x = scalbn ((double)  hb_position->x_offset + x, scale_bits);
+    l->glyphs[i].y = scalbn ((double) -hb_position->y_offset + y, scale_bits);
     x +=  hb_position->x_advance;
     y += -hb_position->y_advance;
 
     hb_position++;
   }
   l->glyphs[i].index = -1;
-  l->glyphs[i].x = scalbn (x, scale_bits);
-  l->glyphs[i].y = scalbn (y, scale_bits);
+  l->glyphs[i].x = scalbn ((double) x, scale_bits);
+  l->glyphs[i].y = scalbn ((double) y, scale_bits);
 
   if (l->num_clusters) {
     memset ((void *) l->clusters, 0, l->num_clusters * sizeof (l->clusters[0]));

--- a/util/options.cc
+++ b/util/options.cc
@@ -569,7 +569,7 @@ font_options_t::get_font (void) const
   else
   {
     for (unsigned int i = 0; i < ARRAY_LENGTH (supported_font_funcs); i++)
-      if (0 == strcasecmp (font_funcs, supported_font_funcs[i].name))
+      if (0 == g_ascii_strcasecmp (font_funcs, supported_font_funcs[i].name))
       {
 	set_font_funcs = supported_font_funcs[i].func;
 	break;

--- a/util/options.hh
+++ b/util/options.hh
@@ -474,5 +474,22 @@ struct format_options_t : option_group_t
   hb_bool_t show_extents;
 };
 
+/* fallback implementation for scalbn()/scalbnf() for pre-2013 MSVC */
+#if defined (_MSC_VER) && (_MSC_VER < 1800)
+
+#ifndef FLT_RADIX
+#define FLT_RADIX 2
+#endif
+
+__inline long double scalbn (long double x, int exp)
+{
+  return x * (pow ((long double) FLT_RADIX, exp));
+}
+
+__inline float scalbnf (float x, int exp)
+{
+  return x * (pow ((float) FLT_RADIX, exp));
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hi,

Sorry for this, was not that good at git and retried a pull request as a result.

I have made some updates to the sources in util/, and also added an implementation of scalbn() and scalbnf() in a header that can be force-included by pre-2013 Visual Studio, so that the tools can be built under Visual Studio as well.

However, it also seems that some more changes are needed... on Visual Studio 2010 and 2008, things went fine, but on 2012 and later, I am getting C2057 (expected constant expression) errors for:

hb-ot-shape-normalize.cc
hb-ot-shape.cc
hb-ot-shape-fallback.cc

When they include hb-ot-layout-private.hh, the error was at line 67 (in the declaration of enum hb_ot_layout_glyph_props_flags_t)

and the C2057 error for hb-glib.cc when it included gnode.h (at line 43 of gnode.h, when the enum GTraverseFlags was declared) from GLib...

There were bitwise or's in the declaration of the enums, so my guess is that the newer Visual Studio compilers are more picky about the overloading of operators, type-wise, or something conflicted in there, as done in hb-private.hh (circa lines 899 to 900)

With blessings, thank you!
