### PR TITLE
include errno.h and strerror where needed

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -41,6 +41,7 @@
 #endif /* HAVE_SYS_MMAN_H */
 
 #include <stdio.h>
+#include <string.h>
 #include <errno.h>
 
 

--- a/src/hb-buffer-serialize.cc
+++ b/src/hb-buffer-serialize.cc
@@ -26,6 +26,8 @@
 
 #include "hb-buffer-private.hh"
 
+#include <errno.h>
+
 
 static const char *serialize_formats[] = {
   "text",

--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -33,6 +33,8 @@
 #include "hb-buffer-private.hh"
 #include "hb-font-private.hh"
 
+#include <errno.h>
+
 /**
  * SECTION:hb-shape
  * @title: Shaping

--- a/util/helper-cairo.cc
+++ b/util/helper-cairo.cc
@@ -30,6 +30,10 @@
 #include <hb-ft.h>
 
 #include "helper-cairo-ansi.hh"
+
+#include <errno.h>
+#include <string.h>
+
 #ifdef CAIRO_HAS_SVG_SURFACE
 #  include <cairo-svg.h>
 #endif

--- a/util/options.cc
+++ b/util/options.cc
@@ -33,6 +33,9 @@
 #include <hb-ot.h>
 #endif
 
+#include <errno.h>
+#include <string.h>
+
 struct supported_font_funcs_t {
 	char name[4];
 	void (*func) (hb_font_t *);

--- a/util/options.hh
+++ b/util/options.hh
@@ -38,7 +38,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <locale.h>
-#include <errno.h>
 #include <fcntl.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h> /* for isatty() */


### PR DESCRIPTION
I notice that errno.h and string.h aren't included consistently when errno and strerror are used, this small patch fixes this.