### PR TITLE
Update opentype language tags

### DIFF
--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -699,8 +699,8 @@ static const LangTag ot_languages[] = {
   {"smj",	HB_TAG('L','S','M',' ')},	/* Lule Sami */
   {"smn",	HB_TAG('I','S','M',' ')},	/* Inari Sami */
   {"sms",	HB_TAG('S','K','S',' ')},	/* Skolt Sami */
-  {"sna",	HB_TAG('S','N','A','0')},	/* Shona */
   {"sn",	HB_TAG('S','N','A',' ')},	/* Shona */
+  {"sna",	HB_TAG('S','N','A','0')},	/* Shona */
   {"snk",	HB_TAG('S','N','K',' ')},	/* Soninke */
   {"so",	HB_TAG('S','M','L',' ')},	/* Somali */
   {"sop",	HB_TAG('S','O','P',' ')},	/* Songe */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -516,7 +516,6 @@ static const LangTag ot_languages[] = {
   {"lrc",	HB_TAG('L','R','C',' ')},	/* Northern Luri */
   {"lt",	HB_TAG('L','T','H',' ')},	/* Lithuanian */
   {"lu",	HB_TAG('L','U','B',' ')},	/* Luba-Katanga */
-  {"lua",	HB_TAG('L','U','A',' ')},	/* Luba-Lulua */
   {"lua",	HB_TAG('L','U','B',' ')},	/* Luba-Kasai */
   {"luo",	HB_TAG('L','U','O',' ')},	/* Luo (Kenya and Tanzania) */
   {"lus",	HB_TAG('M','I','Z',' ')},	/* Mizo */
@@ -816,6 +815,7 @@ static const LangTag ot_languages[] = {
 /*{"kca",	HB_TAG('K','H','S',' ')},*/	/* Khanty-Shurishkar */
 /*{"kca",	HB_TAG('K','H','V',' ')},*/	/* Khanty-Vakhi */
 /*{"kqs, kss",	HB_TAG('K','I','S',' ')},*/	/* Kisii */
+/*{"lua",	HB_TAG('L','U','A',' ')},*/	/* Luba-Lulua */
 /*{"crm",	HB_TAG('L','C','R',' ')},*/	/* L-Cree */
 /*{"csw",	HB_TAG('N','C','R',' ')},*/	/* N-Cree */
 /*{"csw",	HB_TAG('N','H','C',' ')},*/	/* Norway House Cree */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -779,53 +779,48 @@ static const LangTag ot_languages[] = {
   {"zu",	HB_TAG('Z','U','L',' ')}, 	/* Zulu */
   {"zum",	HB_TAG('L','R','C',' ')}	/* Kumzari */
   {"zza",	HB_TAG('Z','Z','A',' ')},	/* Zazaki */
+  {"ahg",	HB_TAG('A','G','W',' ')},	/* Agaw */
+  {"gsw",	HB_TAG('A','L','S',' ')},	/* Alsatian */
+  {"krc",	HB_TAG('B','A','L',' ')},	/* Balkar */
+  {"acf",	HB_TAG('F','A','N',' ')},	/* French Antillean */
+  {"enf",	HB_TAG('F','N','E',' ')},	/* Forest Nenets */
+  {"fuf",	HB_TAG('F','T','A',' ')},	/* Futa */
+  {"flm",	HB_TAG('H','A','L',' ')},	/* Halam */
+  {"gle",	HB_TAG('I','R','T',' ')},	/* Irish Traditional */
+  {"krc",	HB_TAG('K','A','R',' ')},	/* Karachay */
+  {"ktb",	HB_TAG('K','E','B',' ')},	/* Kebena */
+  {"kat",	HB_TAG('K','G','E',' ')},	/* Khutsuri Georgian */
+  {"kca",	HB_TAG('K','H','K',' ')},	/* Khanty-Kazim */
+  {"kca",	HB_TAG('K','H','S',' ')},	/* Khanty-Shurishkar */
+  {"kca",	HB_TAG('K','H','V',' ')},	/* Khanty-Vakhi */
+  {"kqs, kss",	HB_TAG('K','I','S',' ')},	/* Kisii */
+  {"kfa",	HB_TAG('K','O','D',' ')},	/* Kodagu */
+  {"okm",	HB_TAG('K','O','H',' ')},	/* Korean Old Hangul */
+  {"ktu",	HB_TAG('K','O','N',' ')},	/* Kikongo */
+  {"kfx",	HB_TAG('K','U','L',' ')},	/* Kulvi */
+  {"bfu",	HB_TAG('L','A','H',' ')},	/* Lahuli */
+  {"crm",	HB_TAG('L','C','R',' ')},	/* L-Cree */
+  {"mal",	HB_TAG('M','A','L',' ')},	/* Malayalam */
+  {"mlq",	HB_TAG('M','L','N',' ')},	/* Malinke */
+  {"csw",	HB_TAG('N','C','R',' ')},	/* N-Cree */
+  {"csw",	HB_TAG('N','H','C',' ')},	/* Norway House Cree */
+  {"sam",	HB_TAG('P','A','A',' ')},	/* Palestinian Aramaic */
+  {"ell",	HB_TAG('P','G','R',' ')},	/* Polytonic Greek */
+  {"bgr, cnh, cnw, czt, sez, tcp, csy, ctd, flm, pck, tcz, zom, cmr, dao, hlt, cka, cnk, mrh, mwg, cbl, cnb, csh",	HB_TAG('Q','I','N',' ')},	/* Chin */
+  {"atj",	HB_TAG('R','C','R',' ')},	/* R-Cree */
+  {"chp",	HB_TAG('S','A','Y',' ')},	/* Sayisi */
+  {"xan",	HB_TAG('S','E','K',' ')},	/* Sekota */
+  {"ngo",	HB_TAG('S','X','T',' ')},	/* Sutu */
+  {"cwd",	HB_TAG('T','C','R',' ')},	/* TH-Cree */
+  {"enh",	HB_TAG('T','N','E',' ')},	/* Tundra Nenets */
+  {"toi",	HB_TAG('T','N','G',' ')},	/* Tonga */
+  {"crk",	HB_TAG('W','C','R',' ')},	/* West-Cree */
+  {"cre",	HB_TAG('Y','C','R',' ')},	/* Y-Cree */
+  {"iii",	HB_TAG('Y','I','M',' ')},	/* Yi Modern */
+  {"zho",	HB_TAG('Z','H','P',' ')},	/* Chinese Phonetic */
 
   /* The corresponding languages IDs for the following IDs are unclear,
    * overlap, or are architecturally weird. Needs more research. */
-
-/*{"ahg/awn/xan?",	HB_TAG('A','G','W',' ')},*/	/* Agaw */
-/*{"gsw?/gsw-FR?",	HB_TAG('A','L','S',' ')},*/	/* Alsatian */
-/*{"krc",	HB_TAG('B','A','L',' ')},*/	/* Balkar */
-/*{"??",	HB_TAG('B','C','R',' ')},*/	/* Bible Cree */
-/*{"zh?",	HB_TAG('C','H','N',' ')},*/	/* Chinese (seen in Microsoft fonts) */
-/*{"acf/gcf?",	HB_TAG('F','A','N',' ')},*/	/* French Antillean */
-/*{"enf?/yrk?",	HB_TAG('F','N','E',' ')},*/	/* Forest Nenets */
-/*{"fuf?",	HB_TAG('F','T','A',' ')},*/	/* Futa */
-/*{"ar-Syrc?",	HB_TAG('G','A','R',' ')},*/	/* Garshuni */
-/*{"cfm/rnl?",	HB_TAG('H','A','L',' ')},*/	/* Halam */
-/*{"ga-Latg?/Latg?",	HB_TAG('I','R','T',' ')},*/	/* Irish Traditional */
-/*{"krc",	HB_TAG('K','A','R',' ')},*/	/* Karachay */
-/*{"alw?/ktb?",	HB_TAG('K','E','B',' ')},*/	/* Kebena */
-/*{"Geok",	HB_TAG('K','G','E',' ')},*/	/* Khutsuri Georgian */
-/*{"kca",	HB_TAG('K','H','K',' ')},*/	/* Khanty-Kazim */
-/*{"kca",	HB_TAG('K','H','S',' ')},*/	/* Khanty-Shurishkar */
-/*{"kca",	HB_TAG('K','H','V',' ')},*/	/* Khanty-Vakhi */
-/*{"guz?/kqs?/kss?",	HB_TAG('K','I','S',' ')},*/	/* Kisii */
-/*{"kfa/kfi?/kpb?/xua?/xuj?",	HB_TAG('K','O','D',' ')},*/	/* Kodagu */
-/*{"okm?/oko?",	HB_TAG('K','O','H',' ')},*/	/* Korean Old Hangul */
-/*{"kon?/ktu?/...",	HB_TAG('K','O','N',' ')},*/	/* Kikongo */
-/*{"kfx?",	HB_TAG('K','U','L',' ')},*/	/* Kulvi */
-/*{"??",	HB_TAG('L','A','H',' ')},*/	/* Lahuli */
-/*{"??",	HB_TAG('L','C','R',' ')},*/	/* L-Cree */
-/*{"??",	HB_TAG('M','A','L',' ')},*/	/* Malayalam Traditional */
-/*{"mnk?/mlq?/...",	HB_TAG('M','L','N',' ')},*/	/* Malinke */
-/*{"??",	HB_TAG('N','C','R',' ')},*/	/* N-Cree */
-/*{"??",	HB_TAG('N','H','C',' ')},*/	/* Norway House Cree */
-/*{"jpa?/sam?",	HB_TAG('P','A','A',' ')},*/	/* Palestinian Aramaic */
-/*{"polyton",	HB_TAG('P','G','R',' ')},*/	/* Polytonic Greek */
-/*{"??",	HB_TAG('Q','I','N',' ')},*/	/* Asho Chin */
-/*{"??",	HB_TAG('R','C','R',' ')},*/	/* R-Cree */
-/*{"chp?",	HB_TAG('S','A','Y',' ')},*/	/* Sayisi */
-/*{"xan?",	HB_TAG('S','E','K',' ')},*/	/* Sekota */
-/*{"ngo?",	HB_TAG('S','X','T',' ')},*/	/* Sutu */
-/*{"??",	HB_TAG('T','C','R',' ')},*/	/* TH-Cree */
-/*{"tnz?/tog?/toi?",	HB_TAG('T','N','G',' ')},*/	/* Tonga */
-/*{"enh?/yrk?",	HB_TAG('T','N','E',' ')},*/	/* Tundra Nenets */
-/*{"??",	HB_TAG('W','C','R',' ')},*/	/* West-Cree */
-/*{"cre?",	HB_TAG('Y','C','R',' ')},*/	/* Y-Cree */
-/*{"??",	HB_TAG('Y','I','C',' ')},*/	/* Yi Classic */
-/*{"ii?/Yiii?",	HB_TAG('Y','I','M',' ')},*/	/* Yi Modern */
-/*{"??",	HB_TAG('Z','H','P',' ')},*/	/* Chinese Phonetic */
 };
 
 typedef struct {

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -811,6 +811,7 @@ static const LangTag ot_languages[] = {
    * overlap, or are architecturally weird. Needs more research. */
 
 /*{"krc",	HB_TAG('B','A','L',' ')},*/	/* Balkar */
+/*{"hy?",	HB_TAG('H','Y','E','0')},*/	/* Armenian East (ISO 639-3 hye according to Microsoft, but that’s equivalent to ISO 639-1 hy) */
 /*{"krc",	HB_TAG('K','A','R',' ')},*/	/* Karachay */
 /*{"kca",	HB_TAG('K','H','K',' ')},*/	/* Khanty-Kazim */
 /*{"kca",	HB_TAG('K','H','S',' ')},*/	/* Khanty-Shurishkar */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -414,7 +414,7 @@ static const LangTag ot_languages[] = {
   {"ie",	HB_TAG('I','L','E',' ')},	/* Interlingue/Occidental */
   {"ig",	HB_TAG('I','B','O',' ')},	/* Igbo */
   {"igb",	HB_TAG('E','B','I',' ')},	/* Ebira */
-  {"iii",	HB_TAG('Y','I','M',' ')},	/* Yi Modern */
+  {"ii",	HB_TAG('Y','I','M',' ')},	/* Yi Modern */
   {"ijc",	HB_TAG('I','J','O',' ')},	/* Izon */
   {"ijo",	HB_TAG('I','J','O',' ')},	/* Ijo [family] */
   {"ik",	HB_TAG('I','P','K',' ')},	/* Inupiaq [macrolanguage] */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -196,8 +196,8 @@ static const LangTag ot_languages[] = {
   {"aii",	HB_TAG('S','W','A',' ')},	/* Swadaya Aramaic */
   {"aio",	HB_TAG('A','I','O',' ')},	/* Aiton */
   {"aiw",	HB_TAG('A','R','I',' ')},	/* Aari */
-  {"aka",	HB_TAG('A','K','A',' ')},	/* Akan */
   {"ak",	HB_TAG('T','W','I',' ')},	/* Akan [macrolanguage] */
+  {"aka",	HB_TAG('A','K','A',' ')},	/* Akan */
   {"alt",	HB_TAG('A','L','T',' ')},	/* [Southern] Altai */
   {"am",	HB_TAG('A','M','H',' ')},	/* Amharic */
   {"amf",	HB_TAG('H','B','N',' ')},	/* Hammer-Banna */
@@ -218,8 +218,8 @@ static const LangTag ot_languages[] = {
   {"az",	HB_TAG('A','Z','E',' ')},	/* Azerbaijani [macrolanguage] */
   {"azb",	HB_TAG('A','Z','B',' ')},	/* South Azerbaijani */
   {"azj",	HB_TAG('A','Z','E',' ')},	/* North Azerbaijani */
-  {"bad",	HB_TAG('B','A','D','0')},	/* Banda */
   {"ba",	HB_TAG('B','S','H',' ')},	/* Bashkir */
+  {"bad",	HB_TAG('B','A','D','0')},	/* Banda */
   {"bai",	HB_TAG('B','M','L',' ')},	/* Bamileke [family] */
   {"bal",	HB_TAG('B','L','I',' ')},	/* Baluchi [macrolangauge] */
   {"ban",	HB_TAG('B','A','N',' ')},	/* Balinese */
@@ -284,8 +284,8 @@ static const LangTag ot_languages[] = {
   {"ckt",	HB_TAG('C','H','K',' ')},	/* Chukchi */
   {"cop",	HB_TAG('C','O','P',' ')},	/* Coptic */
   {"cpp",	HB_TAG('C','P','P',' ')},	/* Creoles */
-  {"cre",	HB_TAG('Y','C','R',' ')},	/* Y-Cree */
   {"cr",	HB_TAG('C','R','E',' ')},	/* Cree */
+  {"cre",	HB_TAG('Y','C','R',' ')},	/* Y-Cree */
   {"crh",	HB_TAG('C','R','T',' ')},	/* Crimean Tatar */
   {"crj",	HB_TAG('E','C','R',' ')},	/* [Southern] East Cree */
   {"crk",	HB_TAG('W','C','R',' ')},	/* West-Cree */
@@ -328,8 +328,8 @@ static const LangTag ot_languages[] = {
   {"el",	HB_TAG('E','L','L',' ')},	/* Modern Greek (1453-) */
   {"emk",	HB_TAG('E','M','K',' ')},	/* Eastern Maninkakan */
   {"emk",	HB_TAG('M','N','K',' ')},	/* Eastern Maninkakan */
-  {"enf",	HB_TAG('F','N','E',' ')},	/* Forest Nenets */
   {"en",	HB_TAG('E','N','G',' ')},	/* English */
+  {"enf",	HB_TAG('F','N','E',' ')},	/* Forest Nenets */
   {"enh",	HB_TAG('T','N','E',' ')},	/* Tundra Nenets */
   {"eo",	HB_TAG('N','T','O',' ')},	/* Esperanto */
   {"eot",	HB_TAG('B','T','I',' ')},	/* Beti (Côte d'Ivoire) */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -212,8 +212,8 @@ static const LangTag ot_languages[] = {
   {"av",	HB_TAG('A','V','R',' ')},	/* Avaric */
   {"awa",	HB_TAG('A','W','A',' ')},	/* Awadhi */
   {"ay",	HB_TAG('A','Y','M',' ')},	/* Aymara [macrolanguage] */
-  {"azb",	HB_TAG('A','Z','B',' ')},	/* South Azerbaijani */
   {"az",	HB_TAG('A','Z','E',' ')},	/* Azerbaijani [macrolanguage] */
+  {"azb",	HB_TAG('A','Z','B',' ')},	/* South Azerbaijani */
   {"azj",	HB_TAG('A','Z','E',' ')},	/* North Azerbaijani */
   {"bad",	HB_TAG('B','A','D','0')},	/* Banda */
   {"ba",	HB_TAG('B','S','H',' ')},	/* Bashkir */
@@ -694,8 +694,8 @@ static const LangTag ot_languages[] = {
   {"suq",	HB_TAG('S','U','R',' ')},	/* Suri */
   {"sv",	HB_TAG('S','V','E',' ')},	/* Swedish */
   {"sva",	HB_TAG('S','V','A',' ')},	/* Svan */
-  {"swb",	HB_TAG('C','M','R',' ')},	/* Comorian */
   {"sw",	HB_TAG('S','W','K',' ')},	/* Swahili [macrolanguage] */
+  {"swb",	HB_TAG('C','M','R',' ')},	/* Comorian */
   {"swh",	HB_TAG('S','W','K',' ')},	/* Kiswahili/Swahili */
   {"swv",	HB_TAG('M','A','W',' ')},	/* Shekhawati */
   {"sxu",	HB_TAG('S','X','U',' ')},	/* Upper Saxon */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -619,7 +619,6 @@ static const LangTag ot_languages[] = {
   {"pa",	HB_TAG('P','A','N',' ')},	/* Panjabi */
   {"pag",	HB_TAG('P','A','G',' ')},	/* Pangasinan */
   {"pam",	HB_TAG('P','A','M',' ')},	/* Kapampangan/Pampanga */
-  {"pap",	HB_TAG('P','A','P','0')},	/* Papiamentu */
   {"pap",	HB_TAG('P','A','P',' ')},	/* Papiamento */
   {"pau",	HB_TAG('P','A','U',' ')},	/* Palauan */
   {"pcc",	HB_TAG('P','C','C',' ')},	/* Bouyei */
@@ -820,6 +819,7 @@ static const LangTag ot_languages[] = {
 /*{"csw",	HB_TAG('N','C','R',' ')},*/	/* N-Cree */
 /*{"csw",	HB_TAG('N','H','C',' ')},*/	/* Norway House Cree */
 /*{"el-polyton",	HB_TAG('P','G','R',' ')},*/	/* Polytonic Greek */
+/*{"pap",	HB_TAG('P','A','P','0')},*/	/* Papiamentu */
 /*{"bgr, cnh, cnw, czt, sez, tcp, csy, ctd, flm, pck, tcz, zom, cmr, dao, hlt, cka, cnk, mrh, mwg, cbl, cnb, csh",	HB_TAG('Q','I','N',' ')},*/	/* Chin */
 /*{"zh-Latn-pinyin",	HB_TAG('Z','H','P',' ')},*/	/* Chinese Phonetic */
 };

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -798,7 +798,7 @@ static const LangTag ot_languages[] = {
   {"zgh",	HB_TAG('Z','G','H',' ')},	/* Standard Morrocan Tamazigh */
   {"zne",	HB_TAG('Z','N','D',' ')},	/* Zande */
   {"zu",	HB_TAG('Z','U','L',' ')}, 	/* Zulu */
-  {"zum",	HB_TAG('L','R','C',' ')}	/* Kumzari */
+  {"zum",	HB_TAG('L','R','C',' ')},	/* Kumzari */
   {"zza",	HB_TAG('Z','Z','A',' ')},	/* Zazaki */
 
   /* The corresponding languages IDs for the following IDs are unclear,

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -781,32 +781,21 @@ static const LangTag ot_languages[] = {
   {"zza",	HB_TAG('Z','Z','A',' ')},	/* Zazaki */
   {"ahg",	HB_TAG('A','G','W',' ')},	/* Agaw */
   {"gsw",	HB_TAG('A','L','S',' ')},	/* Alsatian */
-  {"krc",	HB_TAG('B','A','L',' ')},	/* Balkar */
   {"acf",	HB_TAG('F','A','N',' ')},	/* French Antillean */
   {"enf",	HB_TAG('F','N','E',' ')},	/* Forest Nenets */
   {"fuf",	HB_TAG('F','T','A',' ')},	/* Futa */
   {"flm",	HB_TAG('H','A','L',' ')},	/* Halam */
   {"gle",	HB_TAG('I','R','T',' ')},	/* Irish Traditional */
-  {"krc",	HB_TAG('K','A','R',' ')},	/* Karachay */
   {"ktb",	HB_TAG('K','E','B',' ')},	/* Kebena */
   {"kat",	HB_TAG('K','G','E',' ')},	/* Khutsuri Georgian */
-  {"kca",	HB_TAG('K','H','K',' ')},	/* Khanty-Kazim */
-  {"kca",	HB_TAG('K','H','S',' ')},	/* Khanty-Shurishkar */
-  {"kca",	HB_TAG('K','H','V',' ')},	/* Khanty-Vakhi */
-  {"kqs, kss",	HB_TAG('K','I','S',' ')},	/* Kisii */
   {"kfa",	HB_TAG('K','O','D',' ')},	/* Kodagu */
   {"okm",	HB_TAG('K','O','H',' ')},	/* Korean Old Hangul */
   {"ktu",	HB_TAG('K','O','N',' ')},	/* Kikongo */
   {"kfx",	HB_TAG('K','U','L',' ')},	/* Kulvi */
   {"bfu",	HB_TAG('L','A','H',' ')},	/* Lahuli */
-  {"crm",	HB_TAG('L','C','R',' ')},	/* L-Cree */
   {"mal",	HB_TAG('M','A','L',' ')},	/* Malayalam */
   {"mlq",	HB_TAG('M','L','N',' ')},	/* Malinke */
-  {"csw",	HB_TAG('N','C','R',' ')},	/* N-Cree */
-  {"csw",	HB_TAG('N','H','C',' ')},	/* Norway House Cree */
   {"sam",	HB_TAG('P','A','A',' ')},	/* Palestinian Aramaic */
-  {"ell",	HB_TAG('P','G','R',' ')},	/* Polytonic Greek */
-  {"bgr, cnh, cnw, czt, sez, tcp, csy, ctd, flm, pck, tcz, zom, cmr, dao, hlt, cka, cnk, mrh, mwg, cbl, cnb, csh",	HB_TAG('Q','I','N',' ')},	/* Chin */
   {"atj",	HB_TAG('R','C','R',' ')},	/* R-Cree */
   {"chp",	HB_TAG('S','A','Y',' ')},	/* Sayisi */
   {"xan",	HB_TAG('S','E','K',' ')},	/* Sekota */
@@ -817,10 +806,22 @@ static const LangTag ot_languages[] = {
   {"crk",	HB_TAG('W','C','R',' ')},	/* West-Cree */
   {"cre",	HB_TAG('Y','C','R',' ')},	/* Y-Cree */
   {"iii",	HB_TAG('Y','I','M',' ')},	/* Yi Modern */
-  {"zho",	HB_TAG('Z','H','P',' ')},	/* Chinese Phonetic */
 
   /* The corresponding languages IDs for the following IDs are unclear,
    * overlap, or are architecturally weird. Needs more research. */
+
+/*{"krc",	HB_TAG('B','A','L',' ')},*/	/* Balkar */
+/*{"krc",	HB_TAG('K','A','R',' ')},*/	/* Karachay */
+/*{"kca",	HB_TAG('K','H','K',' ')},*/	/* Khanty-Kazim */
+/*{"kca",	HB_TAG('K','H','S',' ')},*/	/* Khanty-Shurishkar */
+/*{"kca",	HB_TAG('K','H','V',' ')},*/	/* Khanty-Vakhi */
+/*{"kqs, kss",	HB_TAG('K','I','S',' ')},*/	/* Kisii */
+/*{"crm",	HB_TAG('L','C','R',' ')},*/	/* L-Cree */
+/*{"csw",	HB_TAG('N','C','R',' ')},*/	/* N-Cree */
+/*{"csw",	HB_TAG('N','H','C',' ')},*/	/* Norway House Cree */
+/*{"el-polyton",	HB_TAG('P','G','R',' ')},*/	/* Polytonic Greek */
+/*{"bgr, cnh, cnw, czt, sez, tcp, csy, ctd, flm, pck, tcz, zom, cmr, dao, hlt, cka, cnk, mrh, mwg, cbl, cnb, csh",	HB_TAG('Q','I','N',' ')},*/	/* Chin */
+/*{"zh-Latn-pinyin",	HB_TAG('Z','H','P',' ')},*/	/* Chinese Phonetic */
 };
 
 typedef struct {

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -480,8 +480,7 @@ static const LangTag ot_languages[] = {
   {"krl",	HB_TAG('K','R','L',' ')},	/* Karelian */
   {"kru",	HB_TAG('K','U','U',' ')},	/* Kurukh */
   {"ks",	HB_TAG('K','S','H',' ')},	/* Kashmiri */
-  {"ksh",	HB_TAG('K','S','H','0')},	/* Ripuarian */
-  {"ksh",	HB_TAG('K','S','H',' ')},	/* Kölsch */
+  {"ksh",	HB_TAG('K','S','H','0')},	/* Ripuarian, Kölsch */
 /*{"ksw",	HB_TAG('K','R','N',' ')},*/	/* S'gaw Karen (Microsoft fonts?) */
   {"ksw",	HB_TAG('K','S','W',' ')},	/* S'gaw Karen (OpenType spec and SIL fonts) */
   {"ktb",	HB_TAG('K','E','B',' ')},	/* Kebena */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -197,12 +197,12 @@ static const LangTag ot_languages[] = {
   {"aka",	HB_TAG('A','K','A',' ')},	/* Akan */
   {"ak",	HB_TAG('T','W','I',' ')},	/* Akan [macrolanguage] */
   {"alt",	HB_TAG('A','L','T',' ')},	/* [Southern] Altai */
-  {"amf",	HB_TAG('H','B','N',' ')},	/* Hammer-Banna */
   {"am",	HB_TAG('A','M','H',' ')},	/* Amharic */
-  {"ang",	HB_TAG('A','N','G',' ')},	/* Old English (ca. 450-1100) */
+  {"amf",	HB_TAG('H','B','N',' ')},	/* Hammer-Banna */
   {"an",	HB_TAG('A','R','G',' ')},	/* Aragonese */
-  {"arb",	HB_TAG('A','R','A',' ')},	/* Standard Arabic */
+  {"ang",	HB_TAG('A','N','G',' ')},	/* Old English (ca. 450-1100) */
   {"ar",	HB_TAG('A','R','A',' ')},	/* Arabic [macrolanguage] */
+  {"arb",	HB_TAG('A','R','A',' ')},	/* Standard Arabic */
   {"arn",	HB_TAG('M','A','P',' ')},	/* Mapudungun */
   {"ary",	HB_TAG('M','O','R',' ')},	/* Moroccan Arabic */
   {"as",	HB_TAG('A','S','M',' ')},	/* Assamese */
@@ -232,8 +232,8 @@ static const LangTag ot_languages[] = {
   {"bfq",	HB_TAG('B','A','D',' ')},	/* Badaga */
   {"bft",	HB_TAG('B','L','T',' ')},	/* Balti */
   {"bfy",	HB_TAG('B','A','G',' ')},	/* Baghelkhandi */
-  {"bgc",	HB_TAG('B','G','C',' ')},	/* Haryanvi */
   {"bg",	HB_TAG('B','G','R',' ')},	/* Bulgarian */
+  {"bgc",	HB_TAG('B','G','C',' ')},	/* Haryanvi */
   {"bgq",	HB_TAG('B','G','Q',' ')},	/* Bagri */
   {"bhb",	HB_TAG('B','H','I',' ')},	/* Bhili */
   {"bhk",	HB_TAG('B','I','K',' ')},	/* Albay Bicolano (retired code) */
@@ -252,8 +252,8 @@ static const LangTag ot_languages[] = {
   {"bo",	HB_TAG('T','I','B',' ')},	/* Tibetan */
   {"bpy",	HB_TAG('B','P','Y',' ')},	/* Bishnupriya */
   {"bqi",	HB_TAG('L','R','C',' ')},	/* Bakhtiari */
-  {"bra",	HB_TAG('B','R','I',' ')},	/* Braj Bhasha */
   {"br",	HB_TAG('B','R','E',' ')},	/* Breton */
+  {"bra",	HB_TAG('B','R','I',' ')},	/* Braj Bhasha */
   {"brh",	HB_TAG('B','R','H',' ')},	/* Brahui */
   {"brx",	HB_TAG('B','R','X',' ')},	/* Bodo (India) */
   {"bs",	HB_TAG('B','O','S',' ')},	/* Bosnian */
@@ -266,8 +266,8 @@ static const LangTag ot_languages[] = {
   {"ca",	HB_TAG('C','A','T',' ')},	/* Catalan */
   {"cak",	HB_TAG('C','A','K',' ')},	/* Kaqchikel */
   {"cbk",	HB_TAG('C','B','K',' ')},	/* Chavacano */
-  {"ceb",	HB_TAG('C','E','B',' ')},	/* Cebuano */
   {"ce",	HB_TAG('C','H','E',' ')},	/* Chechen */
+  {"ceb",	HB_TAG('C','E','B',' ')},	/* Cebuano */
   {"cgg",	HB_TAG('C','G','G',' ')},	/* Chiga */
   {"ch",	HB_TAG('C','H','A',' ')},	/* Chamorro */
   {"chk",	HB_TAG('C','H','K','0')},	/* Chuukese */
@@ -285,8 +285,8 @@ static const LangTag ot_languages[] = {
   {"crl",	HB_TAG('E','C','R',' ')},	/* [Northern] East Cree */
   {"crm",	HB_TAG('M','C','R',' ')},	/* Moose Cree */
   {"crx",	HB_TAG('C','R','R',' ')},	/* Carrier */
-  {"csb",	HB_TAG('C','S','B',' ')},	/* Kashubian */
   {"cs",	HB_TAG('C','S','Y',' ')},	/* Czech */
+  {"csb",	HB_TAG('C','S','B',' ')},	/* Kashubian */
   {"ctg",	HB_TAG('C','T','G',' ')},	/* Chittagonian */
   {"cts",	HB_TAG('B','I','K',' ')},	/* Northern Catanduanes Bikol */
   {"cu",	HB_TAG('C','S','L',' ')},	/* Church Slavic */
@@ -338,15 +338,15 @@ static const LangTag ot_languages[] = {
   {"fj",	HB_TAG('F','J','I',' ')},	/* Fijian */
   {"fo",	HB_TAG('F','O','S',' ')},	/* Faroese */
   {"fon",	HB_TAG('F','O','N',' ')},	/* Fon */
-  {"frc",	HB_TAG('F','R','C',' ')},	/* Cajun French */
   {"fr",	HB_TAG('F','R','A',' ')},	/* French */
+  {"frc",	HB_TAG('F','R','C',' ')},	/* Cajun French */
   {"frp",	HB_TAG('F','R','P',' ')},	/* Arpitan/Francoprovençal */
   {"fur",	HB_TAG('F','R','L',' ')},	/* Friulian */
   {"fuv",	HB_TAG('F','U','V',' ')},	/* Nigerian Fulfulde */
   {"fy",	HB_TAG('F','R','I',' ')},	/* Western Frisian */
+  {"ga",	HB_TAG('I','R','I',' ')},	/* Irish */
   {"gaa",	HB_TAG('G','A','D',' ')},	/* Ga */
   {"gag",	HB_TAG('G','A','G',' ')},	/* Gagauz */
-  {"ga",	HB_TAG('I','R','I',' ')},	/* Irish */
   {"gbm",	HB_TAG('G','A','W',' ')},	/* Garhwali */
   {"gd",	HB_TAG('G','A','E',' ')},	/* Scottish Gaelic */
   {"gez",	HB_TAG('G','E','Z',' ')},	/* Ge'ez */
@@ -354,8 +354,8 @@ static const LangTag ot_languages[] = {
   {"gih",	HB_TAG('G','I','H',' ')},	/* Githabul */
   {"gil",	HB_TAG('G','I','L','0')},	/* Kiribati (Gilbertese) */
   {"gkp",	HB_TAG('G','K','P',' ')},	/* Kpelle (Guinea) */
-  {"gld",	HB_TAG('N','A','N',' ')},	/* Nanai */
   {"gl",	HB_TAG('G','A','L',' ')},	/* Galician */
+  {"gld",	HB_TAG('N','A','N',' ')},	/* Nanai */
   {"glk",	HB_TAG('G','L','K',' ')},	/* Gilaki */
   {"gn",	HB_TAG('G','U','A',' ')},	/* Guarani [macrolanguage] */
   {"gnn",	HB_TAG('G','N','N',' ')},	/* Gumatj */
@@ -364,9 +364,9 @@ static const LangTag ot_languages[] = {
   {"gon",	HB_TAG('G','O','N',' ')},	/* Gondi [macrolanguage] */
   {"grt",	HB_TAG('G','R','O',' ')},	/* Garo */
   {"gru",	HB_TAG('S','O','G',' ')},	/* Sodo Gurage */
+  {"gu",	HB_TAG('G','U','J',' ')},	/* Gujarati */
   {"guc",	HB_TAG('G','U','C',' ')},	/* Wayuu */
   {"guf",	HB_TAG('G','U','F',' ')},	/* Gupapuyngu */
-  {"gu",	HB_TAG('G','U','J',' ')},	/* Gujarati */
   {"guk",	HB_TAG('G','M','Z',' ')},	/* Gumuz */
 /*{"guk",	HB_TAG('G','U','K',' ')},*/	/* Gumuz (in SIL fonts) */
   {"guz",	HB_TAG('G','U','Z',' ')},	/* Ekegusii/Gusii */
@@ -383,8 +383,8 @@ static const LangTag ot_languages[] = {
   {"hnd",	HB_TAG('H','N','D',' ')},	/* [Southern] Hindko */
   {"hne",	HB_TAG('C','H','H',' ')},	/* Chattisgarhi */
   {"hno",	HB_TAG('H','N','D',' ')},	/* [Northern] Hindko */
-  {"hoc",	HB_TAG('H','O',' ',' ')},	/* Ho */
   {"ho",	HB_TAG('H','M','O',' ')},	/* Hiri Motu */
+  {"hoc",	HB_TAG('H','O',' ',' ')},	/* Ho */
   {"hoj",	HB_TAG('H','A','R',' ')},	/* Harauti */
   {"hr",	HB_TAG('H','R','V',' ')},	/* Croatian */
   {"hsb",	HB_TAG('U','S','B',' ')},	/* Upper Sorbian */
@@ -393,14 +393,13 @@ static const LangTag ot_languages[] = {
   {"hye",	HB_TAG('H','Y','E','0')},	/* Armenian East */
   {"hy",	HB_TAG('H','Y','E',' ')},	/* Armenian */
   {"hz",	HB_TAG('H','E','R',' ')},	/* Herero */
-  {"hz",	HB_TAG('H','E','R',' ')},	/* Herero */
   {"ia",	HB_TAG('I','N','A',' ')},	/* Interlingua (International Auxiliary Language Association) */
   {"iba",	HB_TAG('I','B','A',' ')},	/* Iban */
   {"ibb",	HB_TAG('I','B','B',' ')},	/* Ibibio */
   {"id",	HB_TAG('I','N','D',' ')},	/* Indonesian */
   {"ie",	HB_TAG('I','L','E',' ')},	/* Interlingue/Occidental */
-  {"igb",	HB_TAG('E','B','I',' ')},	/* Ebira */
   {"ig",	HB_TAG('I','B','O',' ')},	/* Igbo */
+  {"igb",	HB_TAG('E','B','I',' ')},	/* Ebira */
   {"ijc",	HB_TAG('I','J','O',' ')},	/* Izon */
   {"ijo",	HB_TAG('I','J','O',' ')},	/* Ijo [family] */
   {"ik",	HB_TAG('I','P','K',' ')},	/* Inupiaq [macrolanguage] */
@@ -414,10 +413,10 @@ static const LangTag ot_languages[] = {
   {"jam",	HB_TAG('J','A','M',' ')},	/* Jamaican Creole English */
   {"jbo",	HB_TAG('J','B','O',' ')},	/* Lojban */
   {"jv",	HB_TAG('J','A','V',' ')},	/* Javanese */
+  {"ka",	HB_TAG('K','A','T',' ')},	/* Georgian */
   {"kaa",	HB_TAG('K','R','K',' ')},	/* Karakalpak */
   {"kab",	HB_TAG('K','A','B','0')},	/* Kabyle */
   {"kab",	HB_TAG('K','A','B',' ')},	/* Kabyle */
-  {"ka",	HB_TAG('K','A','T',' ')},	/* Georgian */
   {"kam",	HB_TAG('K','M','B',' ')},	/* Kamba (Kenya) */
   {"kar",	HB_TAG('K','R','N',' ')},	/* Karen [family] */
   {"kbd",	HB_TAG('K','A','B',' ')},	/* Kabardian */
@@ -444,8 +443,8 @@ static const LangTag ot_languages[] = {
   {"kk",	HB_TAG('K','A','Z',' ')},	/* Kazakh */
   {"kl",	HB_TAG('G','R','N',' ')},	/* Kalaallisut */
   {"kln",	HB_TAG('K','A','L',' ')},	/* Kalenjin */
-  {"kmb",	HB_TAG('M','B','N',' ')},	/* Kimbundu */
   {"km",	HB_TAG('K','H','M',' ')},	/* Central Khmer */
+  {"kmb",	HB_TAG('M','B','N',' ')},	/* Kimbundu */
   {"kmw",	HB_TAG('K','M','O',' ')},	/* Komo (Democratic Republic of Congo) */
   {"kn",	HB_TAG('K','A','N',' ')},	/* Kannada */
   {"knn",	HB_TAG('K','O','K',' ')},	/* Konkani */
@@ -469,22 +468,22 @@ static const LangTag ot_languages[] = {
   {"ksw",	HB_TAG('K','S','W',' ')},	/* S'gaw Karen (OpenType spec and SIL fonts) */
   {"ku",	HB_TAG('K','U','R',' ')},	/* Kurdish [macrolanguage] */
   {"kum",	HB_TAG('K','U','M',' ')},	/* Kumyk */
-  {"kvd",	HB_TAG('K','U','I',' ')},	/* Kui (Indonesia) */
   {"kv",	HB_TAG('K','O','M',' ')},	/* Komi [macrolanguage] */
+  {"kvd",	HB_TAG('K','U','I',' ')},	/* Kui (Indonesia) */
   {"kw",	HB_TAG('C','O','R',' ')},	/* Cornish */
   {"kxc",	HB_TAG('K','M','S',' ')},	/* Komso */
   {"kxu",	HB_TAG('K','U','I',' ')},	/* Kui (India) */
   {"ky",	HB_TAG('K','I','R',' ')},	/* Kirghiz/Kyrgyz */
   {"kyu",	HB_TAG('K','Y','U',' ')},	/* Western Kayah */
-  {"lad",	HB_TAG('J','U','D',' ')},	/* Ladino */
   {"la",	HB_TAG('L','A','T',' ')},	/* Latin */
-  {"lbe",	HB_TAG('L','A','K',' ')},	/* Lak */
+  {"lad",	HB_TAG('J','U','D',' ')},	/* Ladino */
   {"lb",	HB_TAG('L','T','Z',' ')},	/* Luxembourgish */
+  {"lbe",	HB_TAG('L','A','K',' ')},	/* Lak */
   {"lbj",	HB_TAG('L','D','K',' ')},	/* Ladakhi */
   {"lez",	HB_TAG('L','E','Z',' ')},	/* Lezgi */
   {"lg",	HB_TAG('L','U','G',' ')},	/* Ganda */
-  {"lif",	HB_TAG('L','M','B',' ')},	/* Limbu */
   {"li",	HB_TAG('L','I','M',' ')},	/* Limburgan/Limburger/Limburgish */
+  {"lif",	HB_TAG('L','M','B',' ')},	/* Limbu */
   {"lij",	HB_TAG('L','I','J',' ')},	/* Ligurian */
   {"lis",	HB_TAG('L','I','S',' ')},	/* Lisu */
   {"ljp",	HB_TAG('L','J','P',' ')},	/* Lampung Api */
@@ -497,9 +496,9 @@ static const LangTag ot_languages[] = {
   {"lom",	HB_TAG('L','O','M',' ')},	/* Loma */
   {"lrc",	HB_TAG('L','R','C',' ')},	/* Northern Luri */
   {"lt",	HB_TAG('L','T','H',' ')},	/* Lithuanian */
+  {"lu",	HB_TAG('L','U','B',' ')},	/* Luba-Katanga */
   {"lua",	HB_TAG('L','U','A',' ')},	/* Luba-Lulua */
   {"lua",	HB_TAG('L','U','B',' ')},	/* Luba-Kasai */
-  {"lu",	HB_TAG('L','U','B',' ')},	/* Luba-Katanga */
   {"luo",	HB_TAG('L','U','O',' ')},	/* Luo (Kenya and Tanzania) */
   {"lus",	HB_TAG('M','I','Z',' ')},	/* Mizo */
   {"luy",	HB_TAG('L','U','H',' ')},	/* Luyia/Oluluyia [macrolanguage] */
@@ -529,8 +528,8 @@ static const LangTag ot_languages[] = {
   {"mkw",	HB_TAG('M','K','W',' ')},	/* Kituba (Congo) */
   {"ml",	HB_TAG('M','L','R',' ')},	/* Malayalam */
   {"mlq",	HB_TAG('M','N','K',' ')},	/* Western Maninkakan */
-  {"mnc",	HB_TAG('M','C','H',' ')},	/* Manchu */
   {"mn",	HB_TAG('M','N','G',' ')},	/* Mongolian [macrolanguage] */
+  {"mnc",	HB_TAG('M','C','H',' ')},	/* Manchu */
   {"mni",	HB_TAG('M','N','I',' ')},	/* Manipuri */
   {"mnk",	HB_TAG('M','N','D',' ')},	/* Mandinka */
   {"mns",	HB_TAG('M','A','N',' ')},	/* Mansi */
@@ -541,8 +540,8 @@ static const LangTag ot_languages[] = {
   {"mpe",	HB_TAG('M','A','J',' ')},	/* Majang */
   {"mr",	HB_TAG('M','A','R',' ')},	/* Marathi */
   {"mrj",	HB_TAG('H','M','A',' ')},	/* High Mari */
-  {"msc",	HB_TAG('M','N','K',' ')},	/* Sankaran Maninka */
   {"ms",	HB_TAG('M','L','Y',' ')},	/* Malay [macrolanguage] */
+  {"msc",	HB_TAG('M','N','K',' ')},	/* Sankaran Maninka */
   {"mt",	HB_TAG('M','T','S',' ')},	/* Maltese */
   {"mtr",	HB_TAG('M','A','W',' ')},	/* Mewari */
   {"mus",	HB_TAG('M','U','S',' ')},	/* Creek */
@@ -557,28 +556,28 @@ static const LangTag ot_languages[] = {
   {"myq",	HB_TAG('M','N','K',' ')},	/* Forest Maninka (retired code) */
   {"myv",	HB_TAG('E','R','Z',' ')},	/* Erzya */
   {"mzn",	HB_TAG('M','Z','N',' ')},	/* Mazanderani */
-  {"nag",	HB_TAG('N','A','G',' ')},	/* Naga-Assamese */
   {"na",	HB_TAG('N','A','U',' ')},	/* Nauru */
+  {"nag",	HB_TAG('N','A','G',' ')},	/* Naga-Assamese */
   {"nah",	HB_TAG('N','A','H',' ')},	/* Nahuatl [family] */
   {"nap",	HB_TAG('N','A','P',' ')},	/* Neapolitan */
   {"nb",	HB_TAG('N','O','R',' ')},	/* Norwegian Bokmål */
   {"nco",	HB_TAG('S','I','B',' ')},	/* Sibe */
-  {"ndc",	HB_TAG('N','D','C',' ')},	/* Ndau */
   {"nd",	HB_TAG('N','D','B',' ')},	/* [North] Ndebele */
+  {"ndc",	HB_TAG('N','D','C',' ')},	/* Ndau */
   {"nds",	HB_TAG('N','D','S',' ')},	/* Low German/Low Saxon */
   {"ne",	HB_TAG('N','E','P',' ')},	/* Nepali */
   {"new",	HB_TAG('N','E','W',' ')},	/* Newari */
-  {"nga",	HB_TAG('N','G','A',' ')},	/* Ngabaka */
   {"ng",	HB_TAG('N','D','G',' ')},	/* Ndonga */
+  {"nga",	HB_TAG('N','G','A',' ')},	/* Ngabaka */
   {"ngl",	HB_TAG('L','M','W',' ')},	/* Lomwe */
   {"niu",	HB_TAG('N','I','U',' ')},	/* Niuean */
   {"niv",	HB_TAG('G','I','L',' ')},	/* Gilyak */
   {"nl",	HB_TAG('N','L','D',' ')},	/* Dutch */
   {"nn",	HB_TAG('N','Y','N',' ')},	/* Norwegian Nynorsk */
+  {"no",	HB_TAG('N','O','R',' ')},	/* Norwegian [macrolanguage] */
   {"nod",	HB_TAG('N','T','A',' ')},	/* Northern Thai */
   {"noe",	HB_TAG('N','O','E',' ')},	/* Nimadi */
   {"nog",	HB_TAG('N','O','G',' ')},	/* Nogai */
-  {"no",	HB_TAG('N','O','R',' ')},	/* Norwegian [macrolanguage] */
   {"nov",	HB_TAG('N','O','V',' ')},	/* Novial */
   {"nqo",	HB_TAG('N','K','O',' ')},	/* N'Ko */
   {"nr",	HB_TAG('N','D','B',' ')},	/* [South] Ndebele */
@@ -595,8 +594,8 @@ static const LangTag ot_languages[] = {
   {"om",	HB_TAG('O','R','O',' ')},	/* Oromo [macrolanguage] */
   {"or",	HB_TAG('O','R','I',' ')},	/* Oriya */
   {"os",	HB_TAG('O','S','S',' ')},	/* Ossetian */
-  {"pag",	HB_TAG('P','A','G',' ')},	/* Pangasinan */
   {"pa",	HB_TAG('P','A','N',' ')},	/* Panjabi */
+  {"pag",	HB_TAG('P','A','G',' ')},	/* Pangasinan */
   {"pam",	HB_TAG('P','A','M',' ')},	/* Kapampangan/Pampanga */
   {"pap",	HB_TAG('P','A','P','0')},	/* Papiamentu */
   {"pap",	HB_TAG('P','A','P',' ')},	/* Papiamento */
@@ -620,8 +619,8 @@ static const LangTag ot_languages[] = {
   {"ps",	HB_TAG('P','A','S',' ')},	/* Pashto/Pushto [macrolanguage] */
   {"pt",	HB_TAG('P','T','G',' ')},	/* Portuguese */
   {"pwo",	HB_TAG('P','W','O',' ')},	/* Pwo Western Karen */
-  {"quc",	HB_TAG('Q','U','C',' ')},	/* K'iche'/Quiché */
   {"qu",	HB_TAG('Q','U','Z',' ')},	/* Quechua [macrolanguage] */
+  {"quc",	HB_TAG('Q','U','C',' ')},	/* K'iche'/Quiché */
   {"quh",	HB_TAG('Q','U','H',' ')},	/* Quechua (Bolivia) */
   {"quz",	HB_TAG('Q','U','Z',' ')},	/* Cusco Quechua */
   {"qvi",	HB_TAG('Q','V','I',' ')},	/* Quechua (Ecuador) */
@@ -642,8 +641,8 @@ static const LangTag ot_languages[] = {
   {"ro",	HB_TAG('R','O','M',' ')},	/* Romanian */
   {"rom",	HB_TAG('R','O','Y',' ')},	/* Romany [macrolanguage] */
   {"rtm",	HB_TAG('R','T','M',' ')},	/* Rotuman */
-  {"rue",	HB_TAG('R','S','Y',' ')},	/* Rusyn */
   {"ru",	HB_TAG('R','U','S',' ')},	/* Russian */
+  {"rue",	HB_TAG('R','S','Y',' ')},	/* Rusyn */
   {"rup",	HB_TAG('R','U','P',' ')},	/* Aromanian/Arumanian/Macedo-Romanian */
   {"rw",	HB_TAG('R','U','A',' ')},	/* Kinyarwanda */
   {"rwr",	HB_TAG('M','A','W',' ')},	/* Marwari (India) */
@@ -660,21 +659,21 @@ static const LangTag ot_languages[] = {
   {"se",	HB_TAG('N','S','M',' ')},	/* Northern Sami */
   {"seh",	HB_TAG('S','N','A',' ')},	/* Sena */
   {"sel",	HB_TAG('S','E','L',' ')},	/* Selkup */
-  {"sga",	HB_TAG('S','G','A',' ')},	/* Old Irish (to 900) */
   {"sg",	HB_TAG('S','G','O',' ')},	/* Sango */
+  {"sga",	HB_TAG('S','G','A',' ')},	/* Old Irish (to 900) */
   {"sgs",	HB_TAG('S','G','S',' ')},	/* Samogitian */
   {"sgw",	HB_TAG('C','H','G',' ')},	/* Sebat Bet Gurage */
 /*{"sgw",	HB_TAG('S','G','W',' ')},*/	/* Sebat Bet Gurage (in SIL fonts) */
   {"shi",	HB_TAG('S','H','I',' ')},	/* Tachelhit */
   {"shn",	HB_TAG('S','H','N',' ')},	/* Shan */
-  {"sid",	HB_TAG('S','I','D',' ')},	/* Sidamo */
   {"si",	HB_TAG('S','N','H',' ')},	/* Sinhala */
+  {"sid",	HB_TAG('S','I','D',' ')},	/* Sidamo */
   {"sjd",	HB_TAG('K','S','M',' ')},	/* Kildin Sami */
   {"sk",	HB_TAG('S','K','Y',' ')},	/* Slovak */
   {"skr",	HB_TAG('S','R','K',' ')},	/* Seraiki */
   {"sl",	HB_TAG('S','L','V',' ')},	/* Slovenian */
-  {"sma",	HB_TAG('S','S','M',' ')},	/* Southern Sami */
   {"sm",	HB_TAG('S','M','O',' ')},	/* Samoan */
+  {"sma",	HB_TAG('S','S','M',' ')},	/* Southern Sami */
   {"smj",	HB_TAG('L','S','M',' ')},	/* Lule Sami */
   {"smn",	HB_TAG('I','S','M',' ')},	/* Inari Sami */
   {"sms",	HB_TAG('S','K','S',' ')},	/* Skolt Sami */
@@ -693,8 +692,8 @@ static const LangTag ot_languages[] = {
   {"su",	HB_TAG('S','U','N',' ')},	/* Sundanese */
   {"suk",	HB_TAG('S','U','K',' ')},	/* Sukama */
   {"suq",	HB_TAG('S','U','R',' ')},	/* Suri */
-  {"sva",	HB_TAG('S','V','A',' ')},	/* Svan */
   {"sv",	HB_TAG('S','V','E',' ')},	/* Swedish */
+  {"sva",	HB_TAG('S','V','A',' ')},	/* Svan */
   {"swb",	HB_TAG('C','M','R',' ')},	/* Comorian */
   {"sw",	HB_TAG('S','W','K',' ')},	/* Swahili [macrolanguage] */
   {"swh",	HB_TAG('S','W','K',' ')},	/* Kiswahili/Swahili */
@@ -703,8 +702,8 @@ static const LangTag ot_languages[] = {
   {"syl",	HB_TAG('S','Y','L',' ')},	/* Sylheti */
   {"syr",	HB_TAG('S','Y','R',' ')},	/* Syriac [macrolanguage] */
   {"szl",	HB_TAG('S','Z','L',' ')},	/* Silesian */
-  {"tab",	HB_TAG('T','A','B',' ')},	/* Tabasaran */
   {"ta",	HB_TAG('T','A','M',' ')},	/* Tamil */
+  {"tab",	HB_TAG('T','A','B',' ')},	/* Tabasaran */
   {"tcy",	HB_TAG('T','U','L',' ')},	/* Tulu */
   {"tdd",	HB_TAG('T','D','D',' ')},	/* Tai Nüa */
   {"te",	HB_TAG('T','E','L',' ')},	/* Telugu */
@@ -712,8 +711,8 @@ static const LangTag ot_languages[] = {
   {"tet",	HB_TAG('T','E','T',' ')},	/* Tetum */
   {"tg",	HB_TAG('T','A','J',' ')},	/* Tajik */
   {"th",	HB_TAG('T','H','A',' ')},	/* Thai */
-  {"tig",	HB_TAG('T','G','R',' ')},	/* Tigre */
   {"ti",	HB_TAG('T','G','Y',' ')},	/* Tigrinya */
+  {"tig",	HB_TAG('T','G','R',' ')},	/* Tigre */
   {"tiv",	HB_TAG('T','I','V',' ')},	/* Tiv */
   {"tk",	HB_TAG('T','K','M',' ')},	/* Turkmen */
   {"tl",	HB_TAG('T','G','L',' ')},	/* Tagalog */
@@ -744,8 +743,8 @@ static const LangTag ot_languages[] = {
   {"uz",	HB_TAG('U','Z','B',' ')},	/* Uzbek [macrolanguage] */
   {"uzn",	HB_TAG('U','Z','B',' ')},	/* Northern Uzbek */
   {"uzs",	HB_TAG('U','Z','B',' ')},	/* Southern Uzbek */
-  {"vec",	HB_TAG('V','E','C',' ')},	/* Venetian */
   {"ve",	HB_TAG('V','E','N',' ')},	/* Venda */
+  {"vec",	HB_TAG('V','E','C',' ')},	/* Venetian */
   {"vi",	HB_TAG('V','I','T',' ')},	/* Vietnamese */
   {"vls",	HB_TAG('F','L','E',' ')},	/* Vlaams */
   {"vmw",	HB_TAG('M','A','K',' ')},	/* Makhuwa */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -805,19 +805,26 @@ static const LangTag ot_languages[] = {
    * overlap, or are architecturally weird. Needs more research. */
 
 /*{"krc",	HB_TAG('B','A','L',' ')},*/	/* Balkar */
+/*{"??",	HB_TAG('B','C','R',' ')},*/	/* Bible Cree */
+/*{"zh?",	HB_TAG('C','H','N',' ')},*/	/* Chinese (seen in Microsoft fonts) */
+/*{"ar-Syrc?",	HB_TAG('G','A','R',' ')},*/	/* Garshuni */
 /*{"hy?",	HB_TAG('H','Y','E','0')},*/	/* Armenian East (ISO 639-3 hye according to Microsoft, but that’s equivalent to ISO 639-1 hy) */
+/*{"ga-Latg?/"	HB_TAG('I','R','T',' ')},*/	/* Irish Traditional */
 /*{"krc",	HB_TAG('K','A','R',' ')},*/	/* Karachay */
+/*{"ka-Geok?",	HB_TAG('K','G','E',' ')},*/	/* Khutsuri Georgian */
 /*{"kca",	HB_TAG('K','H','K',' ')},*/	/* Khanty-Kazim */
 /*{"kca",	HB_TAG('K','H','S',' ')},*/	/* Khanty-Shurishkar */
 /*{"kca",	HB_TAG('K','H','V',' ')},*/	/* Khanty-Vakhi */
 /*{"kqs, kss",	HB_TAG('K','I','S',' ')},*/	/* Kisii */
 /*{"lua",	HB_TAG('L','U','A',' ')},*/	/* Luba-Lulua */
 /*{"crm",	HB_TAG('L','C','R',' ')},*/	/* L-Cree */
+/*{"??",	HB_TAG('M','A','L',' ')},*/	/* Malayalam Traditional */
 /*{"csw",	HB_TAG('N','C','R',' ')},*/	/* N-Cree */
 /*{"csw",	HB_TAG('N','H','C',' ')},*/	/* Norway House Cree */
 /*{"el-polyton",	HB_TAG('P','G','R',' ')},*/	/* Polytonic Greek */
 /*{"pap",	HB_TAG('P','A','P','0')},*/	/* Papiamentu */
 /*{"bgr, cnh, cnw, czt, sez, tcp, csy, ctd, flm, pck, tcz, zom, cmr, dao, hlt, cka, cnk, mrh, mwg, cbl, cnb, csh",	HB_TAG('Q','I','N',' ')},*/	/* Chin */
+/*{"??",	HB_TAG('Y','I','C',' ')},*/	/* Yi Classic */
 /*{"zh-Latn-pinyin",	HB_TAG('Z','H','P',' ')},*/	/* Chinese Phonetic */
 };
 

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -617,7 +617,7 @@ static const LangTag ot_languages[] = {
   {"pa",	HB_TAG('P','A','N',' ')},	/* Panjabi */
   {"pag",	HB_TAG('P','A','G',' ')},	/* Pangasinan */
   {"pam",	HB_TAG('P','A','M',' ')},	/* Kapampangan/Pampanga */
-  {"pap",	HB_TAG('P','A','P',' ')},	/* Papiamento */
+  {"pap",	HB_TAG('P','A','P','0')},	/* Papiamento */
   {"pau",	HB_TAG('P','A','U',' ')},	/* Palauan */
   {"pcc",	HB_TAG('P','C','C',' ')},	/* Bouyei */
   {"pcd",	HB_TAG('P','C','D',' ')},	/* Picard */
@@ -822,7 +822,6 @@ static const LangTag ot_languages[] = {
 /*{"csw",	HB_TAG('N','C','R',' ')},*/	/* N-Cree */
 /*{"csw",	HB_TAG('N','H','C',' ')},*/	/* Norway House Cree */
 /*{"el-polyton",	HB_TAG('P','G','R',' ')},*/	/* Polytonic Greek */
-/*{"pap",	HB_TAG('P','A','P','0')},*/	/* Papiamentu */
 /*{"bgr, cnh, cnw, czt, sez, tcp, csy, ctd, flm, pck, tcz, zom, cmr, dao, hlt, cka, cnk, mrh, mwg, cbl, cnb, csh",	HB_TAG('Q','I','N',' ')},*/	/* Chin */
 /*{"??",	HB_TAG('Y','I','C',' ')},*/	/* Yi Classic */
 /*{"zh-Latn-pinyin",	HB_TAG('Z','H','P',' ')},*/	/* Chinese Phonetic */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -186,11 +186,13 @@ static const LangTag ot_languages[] = {
   {"aa",	HB_TAG('A','F','R',' ')},	/* Afar */
   {"ab",	HB_TAG('A','B','K',' ')},	/* Abkhazian */
   {"abq",	HB_TAG('A','B','A',' ')},	/* Abaza */
+  {"acf",	HB_TAG('F','A','N',' ')},	/* French Antillean */
   {"ach",	HB_TAG('A','C','H',' ')},	/* Acoli */
   {"acr",	HB_TAG('A','C','R',' ')},	/* Achi */
   {"ada",	HB_TAG('D','N','G',' ')},	/* Dangme */
   {"ady",	HB_TAG('A','D','Y',' ')},	/* Adyghe */
   {"af",	HB_TAG('A','F','K',' ')},	/* Afrikaans */
+  {"ahg",	HB_TAG('A','G','W',' ')},	/* Agaw */
   {"aii",	HB_TAG('S','W','A',' ')},	/* Swadaya Aramaic */
   {"aio",	HB_TAG('A','I','O',' ')},	/* Aiton */
   {"aiw",	HB_TAG('A','R','I',' ')},	/* Aari */
@@ -208,6 +210,7 @@ static const LangTag ot_languages[] = {
   {"as",	HB_TAG('A','S','M',' ')},	/* Assamese */
   {"ast",	HB_TAG('A','S','T',' ')},	/* Asturian/Asturleonese/Bable/Leonese */
   {"ath",	HB_TAG('A','T','H',' ')},	/* Athapaskan [family] */
+  {"atj",	HB_TAG('R','C','R',' ')},	/* R-Cree */
   {"atv",	HB_TAG('A','L','T',' ')},	/* [Northern] Altai */
   {"av",	HB_TAG('A','V','R',' ')},	/* Avaric */
   {"awa",	HB_TAG('A','W','A',' ')},	/* Awadhi */
@@ -231,6 +234,7 @@ static const LangTag ot_languages[] = {
   {"ber",	HB_TAG('B','E','R',' ')},	/* Berber [family] */
   {"bfq",	HB_TAG('B','A','D',' ')},	/* Badaga */
   {"bft",	HB_TAG('B','L','T',' ')},	/* Balti */
+  {"bfu",	HB_TAG('L','A','H',' ')},	/* Lahuli */
   {"bfy",	HB_TAG('B','A','G',' ')},	/* Baghelkhandi */
   {"bg",	HB_TAG('B','G','R',' ')},	/* Bulgarian */
   {"bgc",	HB_TAG('B','G','C',' ')},	/* Haryanvi */
@@ -273,15 +277,18 @@ static const LangTag ot_languages[] = {
   {"chk",	HB_TAG('C','H','K','0')},	/* Chuukese */
   {"cho",	HB_TAG('C','H','O',' ')},	/* Choctaw */
   {"chp",	HB_TAG('C','H','P',' ')},	/* Chipewyan */
+  {"chp",	HB_TAG('S','A','Y',' ')},	/* Sayisi */
   {"chr",	HB_TAG('C','H','R',' ')},	/* Cherokee */
   {"chy",	HB_TAG('C','H','Y',' ')},	/* Cheyenne */
   {"ckb",	HB_TAG('K','U','R',' ')},	/* Central Kurdish (Sorani) */
   {"ckt",	HB_TAG('C','H','K',' ')},	/* Chukchi */
   {"cop",	HB_TAG('C','O','P',' ')},	/* Coptic */
   {"cpp",	HB_TAG('C','P','P',' ')},	/* Creoles */
+  {"cre",	HB_TAG('Y','C','R',' ')},	/* Y-Cree */
   {"cr",	HB_TAG('C','R','E',' ')},	/* Cree */
   {"crh",	HB_TAG('C','R','T',' ')},	/* Crimean Tatar */
   {"crj",	HB_TAG('E','C','R',' ')},	/* [Southern] East Cree */
+  {"crk",	HB_TAG('W','C','R',' ')},	/* West-Cree */
   {"crl",	HB_TAG('E','C','R',' ')},	/* [Northern] East Cree */
   {"crm",	HB_TAG('M','C','R',' ')},	/* Moose Cree */
   {"crx",	HB_TAG('C','R','R',' ')},	/* Carrier */
@@ -293,6 +300,7 @@ static const LangTag ot_languages[] = {
   {"cuk",	HB_TAG('C','U','K',' ')},	/* San Blas Kuna */
   {"cv",	HB_TAG('C','H','U',' ')},	/* Chuvash */
   {"cwd",	HB_TAG('D','C','R',' ')},	/* Woods Cree */
+  {"cwd",	HB_TAG('T','C','R',' ')},	/* TH-Cree */
   {"cy",	HB_TAG('W','E','L',' ')},	/* Welsh */
   {"da",	HB_TAG('D','A','N',' ')},	/* Danish */
   {"dap",	HB_TAG('N','I','S',' ')},	/* Nisi (India) */
@@ -320,7 +328,9 @@ static const LangTag ot_languages[] = {
   {"el",	HB_TAG('E','L','L',' ')},	/* Modern Greek (1453-) */
   {"emk",	HB_TAG('E','M','K',' ')},	/* Eastern Maninkakan */
   {"emk",	HB_TAG('M','N','K',' ')},	/* Eastern Maninkakan */
+  {"enf",	HB_TAG('F','N','E',' ')},	/* Forest Nenets */
   {"en",	HB_TAG('E','N','G',' ')},	/* English */
+  {"enh",	HB_TAG('T','N','E',' ')},	/* Tundra Nenets */
   {"eo",	HB_TAG('N','T','O',' ')},	/* Esperanto */
   {"eot",	HB_TAG('B','T','I',' ')},	/* Beti (Côte d'Ivoire) */
   {"es",	HB_TAG('E','S','P',' ')},	/* Spanish */
@@ -336,11 +346,13 @@ static const LangTag ot_languages[] = {
   {"fi",	HB_TAG('F','I','N',' ')},	/* Finnish */
   {"fil",	HB_TAG('P','I','L',' ')},	/* Filipino */
   {"fj",	HB_TAG('F','J','I',' ')},	/* Fijian */
+  {"flm",	HB_TAG('H','A','L',' ')},	/* Halam */
   {"fo",	HB_TAG('F','O','S',' ')},	/* Faroese */
   {"fon",	HB_TAG('F','O','N',' ')},	/* Fon */
   {"fr",	HB_TAG('F','R','A',' ')},	/* French */
   {"frc",	HB_TAG('F','R','C',' ')},	/* Cajun French */
   {"frp",	HB_TAG('F','R','P',' ')},	/* Arpitan/Francoprovençal */
+  {"fuf",	HB_TAG('F','T','A',' ')},	/* Futa */
   {"fur",	HB_TAG('F','R','L',' ')},	/* Friulian */
   {"fuv",	HB_TAG('F','U','V',' ')},	/* Nigerian Fulfulde */
   {"fy",	HB_TAG('F','R','I',' ')},	/* Western Frisian */
@@ -355,6 +367,7 @@ static const LangTag ot_languages[] = {
   {"gil",	HB_TAG('G','I','L','0')},	/* Kiribati (Gilbertese) */
   {"gkp",	HB_TAG('G','K','P',' ')},	/* Kpelle (Guinea) */
   {"gl",	HB_TAG('G','A','L',' ')},	/* Galician */
+  {"gle",	HB_TAG('I','R','T',' ')},	/* Irish Traditional */
   {"gld",	HB_TAG('N','A','N',' ')},	/* Nanai */
   {"glk",	HB_TAG('G','L','K',' ')},	/* Gilaki */
   {"gn",	HB_TAG('G','U','A',' ')},	/* Guarani [macrolanguage] */
@@ -364,6 +377,7 @@ static const LangTag ot_languages[] = {
   {"gon",	HB_TAG('G','O','N',' ')},	/* Gondi [macrolanguage] */
   {"grt",	HB_TAG('G','R','O',' ')},	/* Garo */
   {"gru",	HB_TAG('S','O','G',' ')},	/* Sodo Gurage */
+  {"gsw",	HB_TAG('A','L','S',' ')},	/* Alsatian */
   {"gu",	HB_TAG('G','U','J',' ')},	/* Gujarati */
   {"guc",	HB_TAG('G','U','C',' ')},	/* Wayuu */
   {"guf",	HB_TAG('G','U','F',' ')},	/* Gupapuyngu */
@@ -400,6 +414,7 @@ static const LangTag ot_languages[] = {
   {"ie",	HB_TAG('I','L','E',' ')},	/* Interlingue/Occidental */
   {"ig",	HB_TAG('I','B','O',' ')},	/* Igbo */
   {"igb",	HB_TAG('E','B','I',' ')},	/* Ebira */
+  {"iii",	HB_TAG('Y','I','M',' ')},	/* Yi Modern */
   {"ijc",	HB_TAG('I','J','O',' ')},	/* Izon */
   {"ijo",	HB_TAG('I','J','O',' ')},	/* Ijo [family] */
   {"ik",	HB_TAG('I','P','K',' ')},	/* Inupiaq [macrolanguage] */
@@ -419,6 +434,7 @@ static const LangTag ot_languages[] = {
   {"kab",	HB_TAG('K','A','B',' ')},	/* Kabyle */
   {"kam",	HB_TAG('K','M','B',' ')},	/* Kamba (Kenya) */
   {"kar",	HB_TAG('K','R','N',' ')},	/* Karen [family] */
+  {"kat",	HB_TAG('K','G','E',' ')},	/* Khutsuri Georgian */
   {"kbd",	HB_TAG('K','A','B',' ')},	/* Kabardian */
   {"kde",	HB_TAG('K','D','E',' ')},	/* Makonde */
   {"kdr",	HB_TAG('K','R','M',' ')},	/* Karaim */
@@ -426,7 +442,9 @@ static const LangTag ot_languages[] = {
   {"kea",	HB_TAG('K','E','A',' ')},	/* Kabuverdianu (Crioulo) */
   {"kek",	HB_TAG('K','E','K',' ')},	/* Kekchi */
   {"kex",	HB_TAG('K','K','N',' ')},	/* Kokni */
+  {"kfa",	HB_TAG('K','O','D',' ')},	/* Kodagu */
   {"kfr",	HB_TAG('K','A','C',' ')},	/* Kachchi */
+  {"kfx",	HB_TAG('K','U','L',' ')},	/* Kulvi */
   {"kfy",	HB_TAG('K','M','N',' ')},	/* Kumaoni */
   {"kg",	HB_TAG('K','O','N',' ')},	/* Kongo [macrolanguage] */
   {"kha",	HB_TAG('K','S','I',' ')},	/* Khasi */
@@ -466,6 +484,8 @@ static const LangTag ot_languages[] = {
   {"ksh",	HB_TAG('K','S','H',' ')},	/* Kölsch */
 /*{"ksw",	HB_TAG('K','R','N',' ')},*/	/* S'gaw Karen (Microsoft fonts?) */
   {"ksw",	HB_TAG('K','S','W',' ')},	/* S'gaw Karen (OpenType spec and SIL fonts) */
+  {"ktb",	HB_TAG('K','E','B',' ')},	/* Kebena */
+  {"ktu",	HB_TAG('K','O','N',' ')},	/* Kikongo */
   {"ku",	HB_TAG('K','U','R',' ')},	/* Kurdish [macrolanguage] */
   {"kum",	HB_TAG('K','U','M',' ')},	/* Kumyk */
   {"kv",	HB_TAG('K','O','M',' ')},	/* Komi [macrolanguage] */
@@ -509,6 +529,7 @@ static const LangTag ot_languages[] = {
   {"mag",	HB_TAG('M','A','G',' ')},	/* Magahi */
   {"mai",	HB_TAG('M','T','H',' ')},	/* Maithili */
   {"mak",	HB_TAG('M','K','R',' ')},	/* Makasar */
+  {"mal",	HB_TAG('M','A','L',' ')},	/* Malayalam */
   {"mam",	HB_TAG('M','A','M',' ')},	/* Mam */
   {"man",	HB_TAG('M','N','K',' ')},	/* Manding/Mandingo [macrolanguage] */
   {"mdc",	HB_TAG('M','L','E',' ')},	/* Male (Papua New Guinea) */
@@ -527,6 +548,7 @@ static const LangTag ot_languages[] = {
   {"mku",	HB_TAG('M','N','K',' ')},	/* Konyanka Maninka */
   {"mkw",	HB_TAG('M','K','W',' ')},	/* Kituba (Congo) */
   {"ml",	HB_TAG('M','L','R',' ')},	/* Malayalam */
+  {"mlq",	HB_TAG('M','L','N',' ')},	/* Malinke */
   {"mlq",	HB_TAG('M','N','K',' ')},	/* Western Maninkakan */
   {"mn",	HB_TAG('M','N','G',' ')},	/* Mongolian [macrolanguage] */
   {"mnc",	HB_TAG('M','C','H',' ')},	/* Manchu */
@@ -570,6 +592,7 @@ static const LangTag ot_languages[] = {
   {"ng",	HB_TAG('N','D','G',' ')},	/* Ndonga */
   {"nga",	HB_TAG('N','G','A',' ')},	/* Ngabaka */
   {"ngl",	HB_TAG('L','M','W',' ')},	/* Lomwe */
+  {"ngo",	HB_TAG('S','X','T',' ')},	/* Sutu */
   {"niu",	HB_TAG('N','I','U',' ')},	/* Niuean */
   {"niv",	HB_TAG('G','I','L',' ')},	/* Gilyak */
   {"nl",	HB_TAG('N','L','D',' ')},	/* Dutch */
@@ -591,6 +614,7 @@ static const LangTag ot_languages[] = {
   {"oc",	HB_TAG('O','C','I',' ')},	/* Occitan (post 1500) */
   {"oj",	HB_TAG('O','J','B',' ')},	/* Ojibwa [macrolanguage] */
   {"ojs",	HB_TAG('O','C','R',' ')},	/* Oji-Cree */
+  {"okm",	HB_TAG('K','O','H',' ')},	/* Korean Old Hangul */
   {"om",	HB_TAG('O','R','O',' ')},	/* Oromo [macrolanguage] */
   {"or",	HB_TAG('O','R','I',' ')},	/* Oriya */
   {"os",	HB_TAG('O','S','S',' ')},	/* Ossetian */
@@ -648,6 +672,7 @@ static const LangTag ot_languages[] = {
   {"rwr",	HB_TAG('M','A','W',' ')},	/* Marwari (India) */
   {"sa",	HB_TAG('S','A','N',' ')},	/* Sanskrit */
   {"sah",	HB_TAG('Y','A','K',' ')},	/* Yakut */
+  {"sam",	HB_TAG('P','A','A',' ')},	/* Palestinian Aramaic */
   {"sas",	HB_TAG('S','A','S',' ')},	/* Sasak */
   {"sat",	HB_TAG('S','A','T',' ')},	/* Santali */
   {"sc",	HB_TAG('S','R','D',' ')},	/* Sardinian [macrolanguage] */
@@ -721,6 +746,7 @@ static const LangTag ot_languages[] = {
   {"tn",	HB_TAG('T','N','A',' ')},	/* Tswana */
   {"tod",	HB_TAG('T','O','D','0')},	/* Toma */
   {"to",	HB_TAG('T','G','N',' ')},	/* Tonga (Tonga Islands) */
+  {"toi",	HB_TAG('T','N','G',' ')},	/* Tonga */
   {"tpi",	HB_TAG('T','P','I',' ')},	/* Tok Pisin */
   {"tr",	HB_TAG('T','R','K',' ')},	/* Turkish */
   {"tru",	HB_TAG('T','U','A',' ')},	/* Turoyo Aramaic */
@@ -759,6 +785,7 @@ static const LangTag ot_languages[] = {
   {"wry",	HB_TAG('M','A','W',' ')},	/* Merwari */
   {"wtm",	HB_TAG('W','T','M',' ')},	/* Mewati */
   {"xal",	HB_TAG('K','L','M',' ')},	/* Kalmyk */
+  {"xan",	HB_TAG('S','E','K',' ')},	/* Sekota */
   {"xh",	HB_TAG('X','H','S',' ')},	/* Xhosa */
   {"xjb",	HB_TAG('X','J','B',' ')},	/* Minjangbal */
   {"xog",	HB_TAG('X','O','G',' ')},	/* Soga */
@@ -779,33 +806,6 @@ static const LangTag ot_languages[] = {
   {"zu",	HB_TAG('Z','U','L',' ')}, 	/* Zulu */
   {"zum",	HB_TAG('L','R','C',' ')}	/* Kumzari */
   {"zza",	HB_TAG('Z','Z','A',' ')},	/* Zazaki */
-  {"ahg",	HB_TAG('A','G','W',' ')},	/* Agaw */
-  {"gsw",	HB_TAG('A','L','S',' ')},	/* Alsatian */
-  {"acf",	HB_TAG('F','A','N',' ')},	/* French Antillean */
-  {"enf",	HB_TAG('F','N','E',' ')},	/* Forest Nenets */
-  {"fuf",	HB_TAG('F','T','A',' ')},	/* Futa */
-  {"flm",	HB_TAG('H','A','L',' ')},	/* Halam */
-  {"gle",	HB_TAG('I','R','T',' ')},	/* Irish Traditional */
-  {"ktb",	HB_TAG('K','E','B',' ')},	/* Kebena */
-  {"kat",	HB_TAG('K','G','E',' ')},	/* Khutsuri Georgian */
-  {"kfa",	HB_TAG('K','O','D',' ')},	/* Kodagu */
-  {"okm",	HB_TAG('K','O','H',' ')},	/* Korean Old Hangul */
-  {"ktu",	HB_TAG('K','O','N',' ')},	/* Kikongo */
-  {"kfx",	HB_TAG('K','U','L',' ')},	/* Kulvi */
-  {"bfu",	HB_TAG('L','A','H',' ')},	/* Lahuli */
-  {"mal",	HB_TAG('M','A','L',' ')},	/* Malayalam */
-  {"mlq",	HB_TAG('M','L','N',' ')},	/* Malinke */
-  {"sam",	HB_TAG('P','A','A',' ')},	/* Palestinian Aramaic */
-  {"atj",	HB_TAG('R','C','R',' ')},	/* R-Cree */
-  {"chp",	HB_TAG('S','A','Y',' ')},	/* Sayisi */
-  {"xan",	HB_TAG('S','E','K',' ')},	/* Sekota */
-  {"ngo",	HB_TAG('S','X','T',' ')},	/* Sutu */
-  {"cwd",	HB_TAG('T','C','R',' ')},	/* TH-Cree */
-  {"enh",	HB_TAG('T','N','E',' ')},	/* Tundra Nenets */
-  {"toi",	HB_TAG('T','N','G',' ')},	/* Tonga */
-  {"crk",	HB_TAG('W','C','R',' ')},	/* West-Cree */
-  {"cre",	HB_TAG('Y','C','R',' ')},	/* Y-Cree */
-  {"iii",	HB_TAG('Y','I','M',' ')},	/* Yi Modern */
 
   /* The corresponding languages IDs for the following IDs are unclear,
    * overlap, or are architecturally weird. Needs more research. */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -404,7 +404,6 @@ static const LangTag ot_languages[] = {
   {"hsb",	HB_TAG('U','S','B',' ')},	/* Upper Sorbian */
   {"ht",	HB_TAG('H','A','I',' ')},	/* Haitian/Haitian Creole */
   {"hu",	HB_TAG('H','U','N',' ')},	/* Hungarian */
-  {"hye",	HB_TAG('H','Y','E','0')},	/* Armenian East */
   {"hy",	HB_TAG('H','Y','E',' ')},	/* Armenian */
   {"hz",	HB_TAG('H','E','R',' ')},	/* Herero */
   {"ia",	HB_TAG('I','N','A',' ')},	/* Interlingua (International Auxiliary Language Association) */
@@ -431,7 +430,6 @@ static const LangTag ot_languages[] = {
   {"ka",	HB_TAG('K','A','T',' ')},	/* Georgian */
   {"kaa",	HB_TAG('K','R','K',' ')},	/* Karakalpak */
   {"kab",	HB_TAG('K','A','B','0')},	/* Kabyle */
-  {"kab",	HB_TAG('K','A','B',' ')},	/* Kabyle */
   {"kam",	HB_TAG('K','M','B',' ')},	/* Kamba (Kenya) */
   {"kar",	HB_TAG('K','R','N',' ')},	/* Karen [family] */
   {"kat",	HB_TAG('K','G','E',' ')},	/* Khutsuri Georgian */
@@ -699,8 +697,7 @@ static const LangTag ot_languages[] = {
   {"smj",	HB_TAG('L','S','M',' ')},	/* Lule Sami */
   {"smn",	HB_TAG('I','S','M',' ')},	/* Inari Sami */
   {"sms",	HB_TAG('S','K','S',' ')},	/* Skolt Sami */
-  {"sn",	HB_TAG('S','N','A',' ')},	/* Shona */
-  {"sna",	HB_TAG('S','N','A','0')},	/* Shona */
+  {"sn",	HB_TAG('S','N','A','0')},	/* Shona */
   {"snk",	HB_TAG('S','N','K',' ')},	/* Soninke */
   {"so",	HB_TAG('S','M','L',' ')},	/* Somali */
   {"sop",	HB_TAG('S','O','P',' ')},	/* Songe */

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -187,20 +187,22 @@ static const LangTag ot_languages[] = {
   {"ab",	HB_TAG('A','B','K',' ')},	/* Abkhazian */
   {"abq",	HB_TAG('A','B','A',' ')},	/* Abaza */
   {"ach",	HB_TAG('A','C','H',' ')},	/* Acoli */
+  {"acr",	HB_TAG('A','C','R',' ')},	/* Achi */
   {"ada",	HB_TAG('D','N','G',' ')},	/* Dangme */
   {"ady",	HB_TAG('A','D','Y',' ')},	/* Adyghe */
   {"af",	HB_TAG('A','F','K',' ')},	/* Afrikaans */
   {"aii",	HB_TAG('S','W','A',' ')},	/* Swadaya Aramaic */
   {"aio",	HB_TAG('A','I','O',' ')},	/* Aiton */
   {"aiw",	HB_TAG('A','R','I',' ')},	/* Aari */
+  {"aka",	HB_TAG('A','K','A',' ')},	/* Akan */
   {"ak",	HB_TAG('T','W','I',' ')},	/* Akan [macrolanguage] */
   {"alt",	HB_TAG('A','L','T',' ')},	/* [Southern] Altai */
-  {"am",	HB_TAG('A','M','H',' ')},	/* Amharic */
   {"amf",	HB_TAG('H','B','N',' ')},	/* Hammer-Banna */
-  {"an",	HB_TAG('A','R','G',' ')},	/* Aragonese */
+  {"am",	HB_TAG('A','M','H',' ')},	/* Amharic */
   {"ang",	HB_TAG('A','N','G',' ')},	/* Old English (ca. 450-1100) */
-  {"ar",	HB_TAG('A','R','A',' ')},	/* Arabic [macrolanguage] */
+  {"an",	HB_TAG('A','R','G',' ')},	/* Aragonese */
   {"arb",	HB_TAG('A','R','A',' ')},	/* Standard Arabic */
+  {"ar",	HB_TAG('A','R','A',' ')},	/* Arabic [macrolanguage] */
   {"arn",	HB_TAG('M','A','P',' ')},	/* Mapudungun */
   {"ary",	HB_TAG('M','O','R',' ')},	/* Moroccan Arabic */
   {"as",	HB_TAG('A','S','M',' ')},	/* Assamese */
@@ -210,9 +212,10 @@ static const LangTag ot_languages[] = {
   {"av",	HB_TAG('A','V','R',' ')},	/* Avaric */
   {"awa",	HB_TAG('A','W','A',' ')},	/* Awadhi */
   {"ay",	HB_TAG('A','Y','M',' ')},	/* Aymara [macrolanguage] */
-  {"az",	HB_TAG('A','Z','E',' ')},	/* Azerbaijani [macrolanguage] */
   {"azb",	HB_TAG('A','Z','B',' ')},	/* South Azerbaijani */
+  {"az",	HB_TAG('A','Z','E',' ')},	/* Azerbaijani [macrolanguage] */
   {"azj",	HB_TAG('A','Z','E',' ')},	/* North Azerbaijani */
+  {"bad",	HB_TAG('B','A','D','0')},	/* Banda */
   {"ba",	HB_TAG('B','S','H',' ')},	/* Bashkir */
   {"bai",	HB_TAG('B','M','L',' ')},	/* Bamileke [family] */
   {"bal",	HB_TAG('B','L','I',' ')},	/* Baluchi [macrolangauge] */
@@ -222,14 +225,15 @@ static const LangTag ot_languages[] = {
   {"bci",	HB_TAG('B','A','U',' ')},	/* Baoulé */
   {"bcl",	HB_TAG('B','I','K',' ')},	/* Central Bikol */
   {"bcq",	HB_TAG('B','C','H',' ')},	/* Bench */
+  {"bdy",	HB_TAG('B','D','Y',' ')},	/* Bandjalang */
   {"be",	HB_TAG('B','E','L',' ')},	/* Belarusian */
   {"bem",	HB_TAG('B','E','M',' ')},	/* Bemba (Zambia) */
   {"ber",	HB_TAG('B','E','R',' ')},	/* Berber [family] */
   {"bfq",	HB_TAG('B','A','D',' ')},	/* Badaga */
   {"bft",	HB_TAG('B','L','T',' ')},	/* Balti */
   {"bfy",	HB_TAG('B','A','G',' ')},	/* Baghelkhandi */
-  {"bg",	HB_TAG('B','G','R',' ')},	/* Bulgarian */
   {"bgc",	HB_TAG('B','G','C',' ')},	/* Haryanvi */
+  {"bg",	HB_TAG('B','G','R',' ')},	/* Bulgarian */
   {"bgq",	HB_TAG('B','G','Q',' ')},	/* Bagri */
   {"bhb",	HB_TAG('B','H','I',' ')},	/* Bhili */
   {"bhk",	HB_TAG('B','I','K',' ')},	/* Albay Bicolano (retired code) */
@@ -248,8 +252,8 @@ static const LangTag ot_languages[] = {
   {"bo",	HB_TAG('T','I','B',' ')},	/* Tibetan */
   {"bpy",	HB_TAG('B','P','Y',' ')},	/* Bishnupriya */
   {"bqi",	HB_TAG('L','R','C',' ')},	/* Bakhtiari */
-  {"br",	HB_TAG('B','R','E',' ')},	/* Breton */
   {"bra",	HB_TAG('B','R','I',' ')},	/* Braj Bhasha */
+  {"br",	HB_TAG('B','R','E',' ')},	/* Breton */
   {"brh",	HB_TAG('B','R','H',' ')},	/* Brahui */
   {"brx",	HB_TAG('B','R','X',' ')},	/* Bodo (India) */
   {"bs",	HB_TAG('B','O','S',' ')},	/* Bosnian */
@@ -260,11 +264,13 @@ static const LangTag ot_languages[] = {
   {"bxr",	HB_TAG('R','B','U',' ')},	/* Russian Buriat */
   {"byn",	HB_TAG('B','I','L',' ')},	/* Bilen */
   {"ca",	HB_TAG('C','A','T',' ')},	/* Catalan */
+  {"cak",	HB_TAG('C','A','K',' ')},	/* Kaqchikel */
   {"cbk",	HB_TAG('C','B','K',' ')},	/* Chavacano */
-  {"ce",	HB_TAG('C','H','E',' ')},	/* Chechen */
   {"ceb",	HB_TAG('C','E','B',' ')},	/* Cebuano */
+  {"ce",	HB_TAG('C','H','E',' ')},	/* Chechen */
   {"cgg",	HB_TAG('C','G','G',' ')},	/* Chiga */
   {"ch",	HB_TAG('C','H','A',' ')},	/* Chamorro */
+  {"chk",	HB_TAG('C','H','K','0')},	/* Chuukese */
   {"cho",	HB_TAG('C','H','O',' ')},	/* Choctaw */
   {"chp",	HB_TAG('C','H','P',' ')},	/* Chipewyan */
   {"chr",	HB_TAG('C','H','R',' ')},	/* Cherokee */
@@ -272,32 +278,39 @@ static const LangTag ot_languages[] = {
   {"ckb",	HB_TAG('K','U','R',' ')},	/* Central Kurdish (Sorani) */
   {"ckt",	HB_TAG('C','H','K',' ')},	/* Chukchi */
   {"cop",	HB_TAG('C','O','P',' ')},	/* Coptic */
+  {"cpp",	HB_TAG('C','P','P',' ')},	/* Creoles */
   {"cr",	HB_TAG('C','R','E',' ')},	/* Cree */
   {"crh",	HB_TAG('C','R','T',' ')},	/* Crimean Tatar */
   {"crj",	HB_TAG('E','C','R',' ')},	/* [Southern] East Cree */
   {"crl",	HB_TAG('E','C','R',' ')},	/* [Northern] East Cree */
   {"crm",	HB_TAG('M','C','R',' ')},	/* Moose Cree */
   {"crx",	HB_TAG('C','R','R',' ')},	/* Carrier */
-  {"cs",	HB_TAG('C','S','Y',' ')},	/* Czech */
   {"csb",	HB_TAG('C','S','B',' ')},	/* Kashubian */
+  {"cs",	HB_TAG('C','S','Y',' ')},	/* Czech */
   {"ctg",	HB_TAG('C','T','G',' ')},	/* Chittagonian */
   {"cts",	HB_TAG('B','I','K',' ')},	/* Northern Catanduanes Bikol */
   {"cu",	HB_TAG('C','S','L',' ')},	/* Church Slavic */
+  {"cuk",	HB_TAG('C','U','K',' ')},	/* San Blas Kuna */
   {"cv",	HB_TAG('C','H','U',' ')},	/* Chuvash */
   {"cwd",	HB_TAG('D','C','R',' ')},	/* Woods Cree */
   {"cy",	HB_TAG('W','E','L',' ')},	/* Welsh */
   {"da",	HB_TAG('D','A','N',' ')},	/* Danish */
   {"dap",	HB_TAG('N','I','S',' ')},	/* Nisi (India) */
   {"dar",	HB_TAG('D','A','R',' ')},	/* Dargwa */
+  {"dax",	HB_TAG('D','A','X',' ')},	/* Dayi */
   {"de",	HB_TAG('D','E','U',' ')},	/* German */
   {"dgo",	HB_TAG('D','G','O',' ')},	/* Dogri */
   {"dhd",	HB_TAG('M','A','W',' ')},	/* Dhundari */
+  {"dhg",	HB_TAG('D','H','G',' ')},	/* Dhangu */
   {"din",	HB_TAG('D','N','K',' ')},	/* Dinka [macrolanguage] */
   {"diq",	HB_TAG('D','I','Q',' ')},	/* Dimli */
   {"dje",	HB_TAG('D','J','R',' ')},	/* Zarma */
+  {"djr",	HB_TAG('D','J','R','0')},	/* Djambarrpuyngu */
   {"dng",	HB_TAG('D','U','N',' ')},	/* Dungan */
+  {"dnj",	HB_TAG('D','N','J',' ')},	/* Dan */
   {"doi",	HB_TAG('D','G','R',' ')},	/* Dogri [macrolanguage] */
   {"dsb",	HB_TAG('L','S','B',' ')},	/* Lower Sorbian */
+  {"duj",	HB_TAG('D','U','J',' ')},	/* Dhuwal */
   {"dv",	HB_TAG('D','I','V',' ')},	/* Dhivehi/Divehi/Maldivian */
   {"dyu",	HB_TAG('J','U','L',' ')},	/* Jula */
   {"dz",	HB_TAG('D','Z','N',' ')},	/* Dzongkha */
@@ -305,46 +318,55 @@ static const LangTag ot_languages[] = {
   {"efi",	HB_TAG('E','F','I',' ')},	/* Efik */
   {"ekk",	HB_TAG('E','T','I',' ')},	/* Standard Estonian */
   {"el",	HB_TAG('E','L','L',' ')},	/* Modern Greek (1453-) */
+  {"emk",	HB_TAG('E','M','K',' ')},	/* Eastern Maninkakan */
   {"emk",	HB_TAG('M','N','K',' ')},	/* Eastern Maninkakan */
   {"en",	HB_TAG('E','N','G',' ')},	/* English */
   {"eo",	HB_TAG('N','T','O',' ')},	/* Esperanto */
   {"eot",	HB_TAG('B','T','I',' ')},	/* Beti (Côte d'Ivoire) */
   {"es",	HB_TAG('E','S','P',' ')},	/* Spanish */
+  {"esu",	HB_TAG('E','S','U',' ')},	/* Central Yupik */
   {"et",	HB_TAG('E','T','I',' ')},	/* Estonian [macrolanguage] */
   {"eu",	HB_TAG('E','U','Q',' ')},	/* Basque */
   {"eve",	HB_TAG('E','V','N',' ')},	/* Even */
   {"evn",	HB_TAG('E','V','K',' ')},	/* Evenki */
   {"fa",	HB_TAG('F','A','R',' ')},	/* Persian [macrolanguage] */
+  {"fan",	HB_TAG('F','A','N','0')},	/* Fang */
+  {"fat",	HB_TAG('F','A','T',' ')},	/* Fanti */
   {"ff",	HB_TAG('F','U','L',' ')},	/* Fulah [macrolanguage] */
   {"fi",	HB_TAG('F','I','N',' ')},	/* Finnish */
   {"fil",	HB_TAG('P','I','L',' ')},	/* Filipino */
   {"fj",	HB_TAG('F','J','I',' ')},	/* Fijian */
   {"fo",	HB_TAG('F','O','S',' ')},	/* Faroese */
   {"fon",	HB_TAG('F','O','N',' ')},	/* Fon */
-  {"fr",	HB_TAG('F','R','A',' ')},	/* French */
   {"frc",	HB_TAG('F','R','C',' ')},	/* Cajun French */
+  {"fr",	HB_TAG('F','R','A',' ')},	/* French */
   {"frp",	HB_TAG('F','R','P',' ')},	/* Arpitan/Francoprovençal */
   {"fur",	HB_TAG('F','R','L',' ')},	/* Friulian */
   {"fuv",	HB_TAG('F','U','V',' ')},	/* Nigerian Fulfulde */
   {"fy",	HB_TAG('F','R','I',' ')},	/* Western Frisian */
-  {"ga",	HB_TAG('I','R','I',' ')},	/* Irish */
   {"gaa",	HB_TAG('G','A','D',' ')},	/* Ga */
   {"gag",	HB_TAG('G','A','G',' ')},	/* Gagauz */
+  {"ga",	HB_TAG('I','R','I',' ')},	/* Irish */
   {"gbm",	HB_TAG('G','A','W',' ')},	/* Garhwali */
   {"gd",	HB_TAG('G','A','E',' ')},	/* Scottish Gaelic */
   {"gez",	HB_TAG('G','E','Z',' ')},	/* Ge'ez */
   {"ggo",	HB_TAG('G','O','N',' ')},	/* Southern Gondi */
-  {"gl",	HB_TAG('G','A','L',' ')},	/* Galician */
+  {"gih",	HB_TAG('G','I','H',' ')},	/* Githabul */
+  {"gil",	HB_TAG('G','I','L','0')},	/* Kiribati (Gilbertese) */
+  {"gkp",	HB_TAG('G','K','P',' ')},	/* Kpelle (Guinea) */
   {"gld",	HB_TAG('N','A','N',' ')},	/* Nanai */
+  {"gl",	HB_TAG('G','A','L',' ')},	/* Galician */
   {"glk",	HB_TAG('G','L','K',' ')},	/* Gilaki */
   {"gn",	HB_TAG('G','U','A',' ')},	/* Guarani [macrolanguage] */
+  {"gnn",	HB_TAG('G','N','N',' ')},	/* Gumatj */
   {"gno",	HB_TAG('G','O','N',' ')},	/* Northern Gondi */
   {"gog",	HB_TAG('G','O','G',' ')},	/* Gogo */
   {"gon",	HB_TAG('G','O','N',' ')},	/* Gondi [macrolanguage] */
   {"grt",	HB_TAG('G','R','O',' ')},	/* Garo */
   {"gru",	HB_TAG('S','O','G',' ')},	/* Sodo Gurage */
-  {"gu",	HB_TAG('G','U','J',' ')},	/* Gujarati */
   {"guc",	HB_TAG('G','U','C',' ')},	/* Wayuu */
+  {"guf",	HB_TAG('G','U','F',' ')},	/* Gupapuyngu */
+  {"gu",	HB_TAG('G','U','J',' ')},	/* Gujarati */
   {"guk",	HB_TAG('G','M','Z',' ')},	/* Gumuz */
 /*{"guk",	HB_TAG('G','U','K',' ')},*/	/* Gumuz (in SIL fonts) */
   {"guz",	HB_TAG('G','U','Z',' ')},	/* Ekegusii/Gusii */
@@ -355,27 +377,30 @@ static const LangTag ot_languages[] = {
   {"hay",	HB_TAG('H','A','Y',' ')},	/* Haya */
   {"haz",	HB_TAG('H','A','Z',' ')},	/* Hazaragi */
   {"he",	HB_TAG('I','W','R',' ')},	/* Hebrew */
-  {"hz",	HB_TAG('H','E','R',' ')},	/* Herero */
   {"hi",	HB_TAG('H','I','N',' ')},	/* Hindi */
   {"hil",	HB_TAG('H','I','L',' ')},	/* Hiligaynon */
+  {"hmn",	HB_TAG('H','M','N',' ')},	/* Hmong */
   {"hnd",	HB_TAG('H','N','D',' ')},	/* [Southern] Hindko */
   {"hne",	HB_TAG('C','H','H',' ')},	/* Chattisgarhi */
   {"hno",	HB_TAG('H','N','D',' ')},	/* [Northern] Hindko */
-  {"ho",	HB_TAG('H','M','O',' ')},	/* Hiri Motu */
   {"hoc",	HB_TAG('H','O',' ',' ')},	/* Ho */
+  {"ho",	HB_TAG('H','M','O',' ')},	/* Hiri Motu */
   {"hoj",	HB_TAG('H','A','R',' ')},	/* Harauti */
   {"hr",	HB_TAG('H','R','V',' ')},	/* Croatian */
   {"hsb",	HB_TAG('U','S','B',' ')},	/* Upper Sorbian */
   {"ht",	HB_TAG('H','A','I',' ')},	/* Haitian/Haitian Creole */
   {"hu",	HB_TAG('H','U','N',' ')},	/* Hungarian */
+  {"hye",	HB_TAG('H','Y','E','0')},	/* Armenian East */
   {"hy",	HB_TAG('H','Y','E',' ')},	/* Armenian */
   {"hz",	HB_TAG('H','E','R',' ')},	/* Herero */
+  {"hz",	HB_TAG('H','E','R',' ')},	/* Herero */
   {"ia",	HB_TAG('I','N','A',' ')},	/* Interlingua (International Auxiliary Language Association) */
+  {"iba",	HB_TAG('I','B','A',' ')},	/* Iban */
   {"ibb",	HB_TAG('I','B','B',' ')},	/* Ibibio */
   {"id",	HB_TAG('I','N','D',' ')},	/* Indonesian */
   {"ie",	HB_TAG('I','L','E',' ')},	/* Interlingue/Occidental */
-  {"ig",	HB_TAG('I','B','O',' ')},	/* Igbo */
   {"igb",	HB_TAG('E','B','I',' ')},	/* Ebira */
+  {"ig",	HB_TAG('I','B','O',' ')},	/* Igbo */
   {"ijc",	HB_TAG('I','J','O',' ')},	/* Izon */
   {"ijo",	HB_TAG('I','J','O',' ')},	/* Ijo [family] */
   {"ik",	HB_TAG('I','P','K',' ')},	/* Inupiaq [macrolanguage] */
@@ -389,15 +414,18 @@ static const LangTag ot_languages[] = {
   {"jam",	HB_TAG('J','A','M',' ')},	/* Jamaican Creole English */
   {"jbo",	HB_TAG('J','B','O',' ')},	/* Lojban */
   {"jv",	HB_TAG('J','A','V',' ')},	/* Javanese */
-  {"ka",	HB_TAG('K','A','T',' ')},	/* Georgian */
   {"kaa",	HB_TAG('K','R','K',' ')},	/* Karakalpak */
+  {"kab",	HB_TAG('K','A','B','0')},	/* Kabyle */
   {"kab",	HB_TAG('K','A','B',' ')},	/* Kabyle */
+  {"ka",	HB_TAG('K','A','T',' ')},	/* Georgian */
   {"kam",	HB_TAG('K','M','B',' ')},	/* Kamba (Kenya) */
   {"kar",	HB_TAG('K','R','N',' ')},	/* Karen [family] */
   {"kbd",	HB_TAG('K','A','B',' ')},	/* Kabardian */
   {"kde",	HB_TAG('K','D','E',' ')},	/* Makonde */
   {"kdr",	HB_TAG('K','R','M',' ')},	/* Karaim */
   {"kdt",	HB_TAG('K','U','Y',' ')},	/* Kuy */
+  {"kea",	HB_TAG('K','E','A',' ')},	/* Kabuverdianu (Crioulo) */
+  {"kek",	HB_TAG('K','E','K',' ')},	/* Kekchi */
   {"kex",	HB_TAG('K','K','N',' ')},	/* Kokni */
   {"kfr",	HB_TAG('K','A','C',' ')},	/* Kachchi */
   {"kfy",	HB_TAG('K','M','N',' ')},	/* Kumaoni */
@@ -408,20 +436,24 @@ static const LangTag ot_languages[] = {
 /*{"kht",	HB_TAG('K','H','T',' ')},*/	/* Khamti (OpenType spec and SIL fonts) */
   {"khw",	HB_TAG('K','H','W',' ')},	/* Khowar */
   {"ki",	HB_TAG('K','I','K',' ')},	/* Gikuyu/Kikuyu */
+  {"kiu",	HB_TAG('K','I','U',' ')},	/* Kirmanjki */
+  {"kjd",	HB_TAG('K','J','D',' ')},	/* Southern Kiwai */
   {"kj",	HB_TAG('K','U','A',' ')},	/* Kuanyama/Kwanyama */
   {"kjh",	HB_TAG('K','H','A',' ')},	/* Khakass */
   {"kjp",	HB_TAG('K','J','P',' ')},	/* Pwo Eastern Karen */
   {"kk",	HB_TAG('K','A','Z',' ')},	/* Kazakh */
   {"kl",	HB_TAG('G','R','N',' ')},	/* Kalaallisut */
   {"kln",	HB_TAG('K','A','L',' ')},	/* Kalenjin */
-  {"km",	HB_TAG('K','H','M',' ')},	/* Central Khmer */
   {"kmb",	HB_TAG('M','B','N',' ')},	/* Kimbundu */
+  {"km",	HB_TAG('K','H','M',' ')},	/* Central Khmer */
   {"kmw",	HB_TAG('K','M','O',' ')},	/* Komo (Democratic Republic of Congo) */
   {"kn",	HB_TAG('K','A','N',' ')},	/* Kannada */
   {"knn",	HB_TAG('K','O','K',' ')},	/* Konkani */
   {"ko",	HB_TAG('K','O','R',' ')},	/* Korean */
   {"koi",	HB_TAG('K','O','P',' ')},	/* Komi-Permyak */
   {"kok",	HB_TAG('K','O','K',' ')},	/* Konkani [macrolanguage] */
+  {"kon",	HB_TAG('K','O','N','0')},	/* Kongo */
+  {"kos",	HB_TAG('K','O','S',' ')},	/* Kosraean */
   {"kpe",	HB_TAG('K','P','L',' ')},	/* Kpelle [macrolanguage] */
   {"kpv",	HB_TAG('K','O','Z',' ')},	/* Komi-Zyrian */
   {"kpy",	HB_TAG('K','Y','K',' ')},	/* Koryak */
@@ -431,27 +463,28 @@ static const LangTag ot_languages[] = {
   {"krl",	HB_TAG('K','R','L',' ')},	/* Karelian */
   {"kru",	HB_TAG('K','U','U',' ')},	/* Kurukh */
   {"ks",	HB_TAG('K','S','H',' ')},	/* Kashmiri */
+  {"ksh",	HB_TAG('K','S','H','0')},	/* Ripuarian */
   {"ksh",	HB_TAG('K','S','H',' ')},	/* Kölsch */
 /*{"ksw",	HB_TAG('K','R','N',' ')},*/	/* S'gaw Karen (Microsoft fonts?) */
   {"ksw",	HB_TAG('K','S','W',' ')},	/* S'gaw Karen (OpenType spec and SIL fonts) */
   {"ku",	HB_TAG('K','U','R',' ')},	/* Kurdish [macrolanguage] */
   {"kum",	HB_TAG('K','U','M',' ')},	/* Kumyk */
-  {"kv",	HB_TAG('K','O','M',' ')},	/* Komi [macrolanguage] */
   {"kvd",	HB_TAG('K','U','I',' ')},	/* Kui (Indonesia) */
+  {"kv",	HB_TAG('K','O','M',' ')},	/* Komi [macrolanguage] */
   {"kw",	HB_TAG('C','O','R',' ')},	/* Cornish */
   {"kxc",	HB_TAG('K','M','S',' ')},	/* Komso */
   {"kxu",	HB_TAG('K','U','I',' ')},	/* Kui (India) */
   {"ky",	HB_TAG('K','I','R',' ')},	/* Kirghiz/Kyrgyz */
   {"kyu",	HB_TAG('K','Y','U',' ')},	/* Western Kayah */
-  {"la",	HB_TAG('L','A','T',' ')},	/* Latin */
   {"lad",	HB_TAG('J','U','D',' ')},	/* Ladino */
-  {"lb",	HB_TAG('L','T','Z',' ')},	/* Luxembourgish */
+  {"la",	HB_TAG('L','A','T',' ')},	/* Latin */
   {"lbe",	HB_TAG('L','A','K',' ')},	/* Lak */
+  {"lb",	HB_TAG('L','T','Z',' ')},	/* Luxembourgish */
   {"lbj",	HB_TAG('L','D','K',' ')},	/* Ladakhi */
   {"lez",	HB_TAG('L','E','Z',' ')},	/* Lezgi */
   {"lg",	HB_TAG('L','U','G',' ')},	/* Ganda */
-  {"li",	HB_TAG('L','I','M',' ')},	/* Limburgan/Limburger/Limburgish */
   {"lif",	HB_TAG('L','M','B',' ')},	/* Limbu */
+  {"li",	HB_TAG('L','I','M',' ')},	/* Limburgan/Limburger/Limburgish */
   {"lij",	HB_TAG('L','I','J',' ')},	/* Ligurian */
   {"lis",	HB_TAG('L','I','S',' ')},	/* Lisu */
   {"ljp",	HB_TAG('L','J','P',' ')},	/* Lampung Api */
@@ -461,10 +494,12 @@ static const LangTag ot_languages[] = {
   {"lmo",	HB_TAG('L','M','O',' ')},	/* Lombard */
   {"ln",	HB_TAG('L','I','N',' ')},	/* Lingala */
   {"lo",	HB_TAG('L','A','O',' ')},	/* Lao */
+  {"lom",	HB_TAG('L','O','M',' ')},	/* Loma */
   {"lrc",	HB_TAG('L','R','C',' ')},	/* Northern Luri */
   {"lt",	HB_TAG('L','T','H',' ')},	/* Lithuanian */
-  {"lu",	HB_TAG('L','U','B',' ')},	/* Luba-Katanga */
+  {"lua",	HB_TAG('L','U','A',' ')},	/* Luba-Lulua */
   {"lua",	HB_TAG('L','U','B',' ')},	/* Luba-Kasai */
+  {"lu",	HB_TAG('L','U','B',' ')},	/* Luba-Katanga */
   {"luo",	HB_TAG('L','U','O',' ')},	/* Luo (Kenya and Tanzania) */
   {"lus",	HB_TAG('M','I','Z',' ')},	/* Mizo */
   {"luy",	HB_TAG('L','U','H',' ')},	/* Luyia/Oluluyia [macrolanguage] */
@@ -475,6 +510,7 @@ static const LangTag ot_languages[] = {
   {"mag",	HB_TAG('M','A','G',' ')},	/* Magahi */
   {"mai",	HB_TAG('M','T','H',' ')},	/* Maithili */
   {"mak",	HB_TAG('M','K','R',' ')},	/* Makasar */
+  {"mam",	HB_TAG('M','A','M',' ')},	/* Mam */
   {"man",	HB_TAG('M','N','K',' ')},	/* Manding/Mandingo [macrolanguage] */
   {"mdc",	HB_TAG('M','L','E',' ')},	/* Male (Papua New Guinea) */
   {"mdf",	HB_TAG('M','O','K',' ')},	/* Moksha */
@@ -493,8 +529,8 @@ static const LangTag ot_languages[] = {
   {"mkw",	HB_TAG('M','K','W',' ')},	/* Kituba (Congo) */
   {"ml",	HB_TAG('M','L','R',' ')},	/* Malayalam */
   {"mlq",	HB_TAG('M','N','K',' ')},	/* Western Maninkakan */
-  {"mn",	HB_TAG('M','N','G',' ')},	/* Mongolian [macrolanguage] */
   {"mnc",	HB_TAG('M','C','H',' ')},	/* Manchu */
+  {"mn",	HB_TAG('M','N','G',' ')},	/* Mongolian [macrolanguage] */
   {"mni",	HB_TAG('M','N','I',' ')},	/* Manipuri */
   {"mnk",	HB_TAG('M','N','D',' ')},	/* Mandinka */
   {"mns",	HB_TAG('M','A','N',' ')},	/* Mansi */
@@ -505,8 +541,8 @@ static const LangTag ot_languages[] = {
   {"mpe",	HB_TAG('M','A','J',' ')},	/* Majang */
   {"mr",	HB_TAG('M','A','R',' ')},	/* Marathi */
   {"mrj",	HB_TAG('H','M','A',' ')},	/* High Mari */
-  {"ms",	HB_TAG('M','L','Y',' ')},	/* Malay [macrolanguage] */
   {"msc",	HB_TAG('M','N','K',' ')},	/* Sankaran Maninka */
+  {"ms",	HB_TAG('M','L','Y',' ')},	/* Malay [macrolanguage] */
   {"mt",	HB_TAG('M','T','S',' ')},	/* Maltese */
   {"mtr",	HB_TAG('M','A','W',' ')},	/* Mewari */
   {"mus",	HB_TAG('M','U','S',' ')},	/* Creek */
@@ -517,35 +553,37 @@ static const LangTag ot_languages[] = {
   {"mww",	HB_TAG('M','W','W',' ')},	/* Hmong Daw */
   {"my",	HB_TAG('B','R','M',' ')},	/* Burmese */
   {"mym",	HB_TAG('M','E','N',' ')},	/* Me'en */
+  {"myn",	HB_TAG('M','Y','N',' ')},	/* Mayan */
   {"myq",	HB_TAG('M','N','K',' ')},	/* Forest Maninka (retired code) */
   {"myv",	HB_TAG('E','R','Z',' ')},	/* Erzya */
   {"mzn",	HB_TAG('M','Z','N',' ')},	/* Mazanderani */
-  {"na",	HB_TAG('N','A','U',' ')},	/* Nauru */
   {"nag",	HB_TAG('N','A','G',' ')},	/* Naga-Assamese */
+  {"na",	HB_TAG('N','A','U',' ')},	/* Nauru */
   {"nah",	HB_TAG('N','A','H',' ')},	/* Nahuatl [family] */
   {"nap",	HB_TAG('N','A','P',' ')},	/* Neapolitan */
   {"nb",	HB_TAG('N','O','R',' ')},	/* Norwegian Bokmål */
   {"nco",	HB_TAG('S','I','B',' ')},	/* Sibe */
-  {"nd",	HB_TAG('N','D','B',' ')},	/* [North] Ndebele */
   {"ndc",	HB_TAG('N','D','C',' ')},	/* Ndau */
+  {"nd",	HB_TAG('N','D','B',' ')},	/* [North] Ndebele */
   {"nds",	HB_TAG('N','D','S',' ')},	/* Low German/Low Saxon */
   {"ne",	HB_TAG('N','E','P',' ')},	/* Nepali */
   {"new",	HB_TAG('N','E','W',' ')},	/* Newari */
-  {"ng",	HB_TAG('N','D','G',' ')},	/* Ndonga */
   {"nga",	HB_TAG('N','G','A',' ')},	/* Ngabaka */
+  {"ng",	HB_TAG('N','D','G',' ')},	/* Ndonga */
   {"ngl",	HB_TAG('L','M','W',' ')},	/* Lomwe */
   {"niu",	HB_TAG('N','I','U',' ')},	/* Niuean */
   {"niv",	HB_TAG('G','I','L',' ')},	/* Gilyak */
   {"nl",	HB_TAG('N','L','D',' ')},	/* Dutch */
   {"nn",	HB_TAG('N','Y','N',' ')},	/* Norwegian Nynorsk */
-  {"no",	HB_TAG('N','O','R',' ')},	/* Norwegian [macrolanguage] */
   {"nod",	HB_TAG('N','T','A',' ')},	/* Northern Thai */
   {"noe",	HB_TAG('N','O','E',' ')},	/* Nimadi */
   {"nog",	HB_TAG('N','O','G',' ')},	/* Nogai */
+  {"no",	HB_TAG('N','O','R',' ')},	/* Norwegian [macrolanguage] */
   {"nov",	HB_TAG('N','O','V',' ')},	/* Novial */
   {"nqo",	HB_TAG('N','K','O',' ')},	/* N'Ko */
   {"nr",	HB_TAG('N','D','B',' ')},	/* [South] Ndebele */
   {"nsk",	HB_TAG('N','A','S',' ')},	/* Naskapi */
+  {"nso",	HB_TAG('N','S','O',' ')},	/* Sotho, Northern */
   {"nso",	HB_TAG('S','O','T',' ')},	/* [Northern] Sotho */
   {"nv",	HB_TAG('N','A','V',' ')},	/* Navajo */
   {"ny",	HB_TAG('C','H','I',' ')},	/* Chewa/Chichwa/Nyanja */
@@ -557,10 +595,12 @@ static const LangTag ot_languages[] = {
   {"om",	HB_TAG('O','R','O',' ')},	/* Oromo [macrolanguage] */
   {"or",	HB_TAG('O','R','I',' ')},	/* Oriya */
   {"os",	HB_TAG('O','S','S',' ')},	/* Ossetian */
-  {"pa",	HB_TAG('P','A','N',' ')},	/* Panjabi */
   {"pag",	HB_TAG('P','A','G',' ')},	/* Pangasinan */
+  {"pa",	HB_TAG('P','A','N',' ')},	/* Panjabi */
   {"pam",	HB_TAG('P','A','M',' ')},	/* Kapampangan/Pampanga */
+  {"pap",	HB_TAG('P','A','P','0')},	/* Papiamentu */
   {"pap",	HB_TAG('P','A','P',' ')},	/* Papiamento */
+  {"pau",	HB_TAG('P','A','U',' ')},	/* Palauan */
   {"pcc",	HB_TAG('P','C','C',' ')},	/* Bouyei */
   {"pcd",	HB_TAG('P','C','D',' ')},	/* Picard */
   {"pce",	HB_TAG('P','L','G',' ')},	/* [Ruching] Palaung */
@@ -574,26 +614,36 @@ static const LangTag ot_languages[] = {
   {"plp",	HB_TAG('P','A','P',' ')},	/* Palpa */
   {"pms",	HB_TAG('P','M','S',' ')},	/* Piemontese */
   {"pnb",	HB_TAG('P','N','B',' ')},	/* Western Panjabi */
+  {"poh",	HB_TAG('P','O','H',' ')},	/* Pocomchi */
+  {"pon",	HB_TAG('P','O','N',' ')},	/* Pohnpeian */
   {"prs",	HB_TAG('D','R','I',' ')},	/* Afghan Persian/Dari */
   {"ps",	HB_TAG('P','A','S',' ')},	/* Pashto/Pushto [macrolanguage] */
   {"pt",	HB_TAG('P','T','G',' ')},	/* Portuguese */
   {"pwo",	HB_TAG('P','W','O',' ')},	/* Pwo Western Karen */
-  {"qu",	HB_TAG('Q','U','Z',' ')},	/* Quechua [macrolanguage] */
   {"quc",	HB_TAG('Q','U','C',' ')},	/* K'iche'/Quiché */
+  {"qu",	HB_TAG('Q','U','Z',' ')},	/* Quechua [macrolanguage] */
+  {"quh",	HB_TAG('Q','U','H',' ')},	/* Quechua (Bolivia) */
   {"quz",	HB_TAG('Q','U','Z',' ')},	/* Cusco Quechua */
+  {"qvi",	HB_TAG('Q','V','I',' ')},	/* Quechua (Ecuador) */
+  {"qwh",	HB_TAG('Q','W','H',' ')},	/* Quechua (Peru) */
   {"raj",	HB_TAG('R','A','J',' ')},	/* Rajasthani [macrolanguage] */
+  {"rar",	HB_TAG('R','A','R',' ')},	/* Rarotongan */
   {"rbb",	HB_TAG('P','L','G',' ')},	/* Rumai Palaung */
   {"rej",	HB_TAG('R','E','J',' ')},	/* Rejang */
   {"ria",	HB_TAG('R','I','A',' ')},	/* Riang (India) */
+  {"rif",	HB_TAG('R','I','F',' ')},	/* Tarifit */
   {"ril",	HB_TAG('R','I','A',' ')},	/* Riang (Myanmar) */
+  {"rit",	HB_TAG('R','I','T',' ')},	/* Ritarungo */
   {"rki",	HB_TAG('A','R','K',' ')},	/* Rakhine */
+  {"rkw",	HB_TAG('R','K','W',' ')},	/* Arakwal */
   {"rm",	HB_TAG('R','M','S',' ')},	/* Romansh */
   {"rmy",	HB_TAG('R','M','Y',' ')},	/* Vlax Romani */
   {"rn",	HB_TAG('R','U','N',' ')},	/* Rundi */
   {"ro",	HB_TAG('R','O','M',' ')},	/* Romanian */
   {"rom",	HB_TAG('R','O','Y',' ')},	/* Romany [macrolanguage] */
-  {"ru",	HB_TAG('R','U','S',' ')},	/* Russian */
+  {"rtm",	HB_TAG('R','T','M',' ')},	/* Rotuman */
   {"rue",	HB_TAG('R','S','Y',' ')},	/* Rusyn */
+  {"ru",	HB_TAG('R','U','S',' ')},	/* Russian */
   {"rup",	HB_TAG('R','U','P',' ')},	/* Aromanian/Arumanian/Macedo-Romanian */
   {"rw",	HB_TAG('R','U','A',' ')},	/* Kinyarwanda */
   {"rwr",	HB_TAG('M','A','W',' ')},	/* Marwari (India) */
@@ -601,8 +651,8 @@ static const LangTag ot_languages[] = {
   {"sah",	HB_TAG('Y','A','K',' ')},	/* Yakut */
   {"sas",	HB_TAG('S','A','S',' ')},	/* Sasak */
   {"sat",	HB_TAG('S','A','T',' ')},	/* Santali */
-  {"sck",	HB_TAG('S','A','D',' ')},	/* Sadri */
   {"sc",	HB_TAG('S','R','D',' ')},	/* Sardinian [macrolanguage] */
+  {"sck",	HB_TAG('S','A','D',' ')},	/* Sadri */
   {"scn",	HB_TAG('S','C','N',' ')},	/* Sicilian */
   {"sco",	HB_TAG('S','C','O',' ')},	/* Scots */
   {"scs",	HB_TAG('S','L','A',' ')},	/* [North] Slavey */
@@ -610,23 +660,25 @@ static const LangTag ot_languages[] = {
   {"se",	HB_TAG('N','S','M',' ')},	/* Northern Sami */
   {"seh",	HB_TAG('S','N','A',' ')},	/* Sena */
   {"sel",	HB_TAG('S','E','L',' ')},	/* Selkup */
-  {"sg",	HB_TAG('S','G','O',' ')},	/* Sango */
   {"sga",	HB_TAG('S','G','A',' ')},	/* Old Irish (to 900) */
+  {"sg",	HB_TAG('S','G','O',' ')},	/* Sango */
   {"sgs",	HB_TAG('S','G','S',' ')},	/* Samogitian */
   {"sgw",	HB_TAG('C','H','G',' ')},	/* Sebat Bet Gurage */
 /*{"sgw",	HB_TAG('S','G','W',' ')},*/	/* Sebat Bet Gurage (in SIL fonts) */
+  {"shi",	HB_TAG('S','H','I',' ')},	/* Tachelhit */
   {"shn",	HB_TAG('S','H','N',' ')},	/* Shan */
-  {"si",	HB_TAG('S','N','H',' ')},	/* Sinhala */
   {"sid",	HB_TAG('S','I','D',' ')},	/* Sidamo */
+  {"si",	HB_TAG('S','N','H',' ')},	/* Sinhala */
   {"sjd",	HB_TAG('K','S','M',' ')},	/* Kildin Sami */
   {"sk",	HB_TAG('S','K','Y',' ')},	/* Slovak */
   {"skr",	HB_TAG('S','R','K',' ')},	/* Seraiki */
   {"sl",	HB_TAG('S','L','V',' ')},	/* Slovenian */
-  {"sm",	HB_TAG('S','M','O',' ')},	/* Samoan */
   {"sma",	HB_TAG('S','S','M',' ')},	/* Southern Sami */
+  {"sm",	HB_TAG('S','M','O',' ')},	/* Samoan */
   {"smj",	HB_TAG('L','S','M',' ')},	/* Lule Sami */
   {"smn",	HB_TAG('I','S','M',' ')},	/* Inari Sami */
   {"sms",	HB_TAG('S','K','S',' ')},	/* Skolt Sami */
+  {"sna",	HB_TAG('S','N','A','0')},	/* Shona */
   {"sn",	HB_TAG('S','N','A',' ')},	/* Shona */
   {"snk",	HB_TAG('S','N','K',' ')},	/* Soninke */
   {"so",	HB_TAG('S','M','L',' ')},	/* Somali */
@@ -641,18 +693,18 @@ static const LangTag ot_languages[] = {
   {"su",	HB_TAG('S','U','N',' ')},	/* Sundanese */
   {"suk",	HB_TAG('S','U','K',' ')},	/* Sukama */
   {"suq",	HB_TAG('S','U','R',' ')},	/* Suri */
-  {"sv",	HB_TAG('S','V','E',' ')},	/* Swedish */
   {"sva",	HB_TAG('S','V','A',' ')},	/* Svan */
-  {"sw",	HB_TAG('S','W','K',' ')},	/* Swahili [macrolanguage] */
+  {"sv",	HB_TAG('S','V','E',' ')},	/* Swedish */
   {"swb",	HB_TAG('C','M','R',' ')},	/* Comorian */
+  {"sw",	HB_TAG('S','W','K',' ')},	/* Swahili [macrolanguage] */
   {"swh",	HB_TAG('S','W','K',' ')},	/* Kiswahili/Swahili */
   {"swv",	HB_TAG('M','A','W',' ')},	/* Shekhawati */
   {"sxu",	HB_TAG('S','X','U',' ')},	/* Upper Saxon */
   {"syl",	HB_TAG('S','Y','L',' ')},	/* Sylheti */
   {"syr",	HB_TAG('S','Y','R',' ')},	/* Syriac [macrolanguage] */
   {"szl",	HB_TAG('S','Z','L',' ')},	/* Silesian */
-  {"ta",	HB_TAG('T','A','M',' ')},	/* Tamil */
   {"tab",	HB_TAG('T','A','B',' ')},	/* Tabasaran */
+  {"ta",	HB_TAG('T','A','M',' ')},	/* Tamil */
   {"tcy",	HB_TAG('T','U','L',' ')},	/* Tulu */
   {"tdd",	HB_TAG('T','D','D',' ')},	/* Tai Nüa */
   {"te",	HB_TAG('T','E','L',' ')},	/* Telugu */
@@ -660,13 +712,15 @@ static const LangTag ot_languages[] = {
   {"tet",	HB_TAG('T','E','T',' ')},	/* Tetum */
   {"tg",	HB_TAG('T','A','J',' ')},	/* Tajik */
   {"th",	HB_TAG('T','H','A',' ')},	/* Thai */
-  {"ti",	HB_TAG('T','G','Y',' ')},	/* Tigrinya */
   {"tig",	HB_TAG('T','G','R',' ')},	/* Tigre */
+  {"ti",	HB_TAG('T','G','Y',' ')},	/* Tigrinya */
   {"tiv",	HB_TAG('T','I','V',' ')},	/* Tiv */
   {"tk",	HB_TAG('T','K','M',' ')},	/* Turkmen */
   {"tl",	HB_TAG('T','G','L',' ')},	/* Tagalog */
+  {"tmh",	HB_TAG('T','M','H',' ')},	/* Tamashek */
   {"tmh",	HB_TAG('t','m','h',' ')},	/* Tamashek [macrolanguage] */
   {"tn",	HB_TAG('T','N','A',' ')},	/* Tswana */
+  {"tod",	HB_TAG('T','O','D','0')},	/* Toma */
   {"to",	HB_TAG('T','G','N',' ')},	/* Tonga (Tonga Islands) */
   {"tpi",	HB_TAG('T','P','I',' ')},	/* Tok Pisin */
   {"tr",	HB_TAG('T','R','K',' ')},	/* Turkish */
@@ -674,11 +728,13 @@ static const LangTag ot_languages[] = {
   {"ts",	HB_TAG('T','S','G',' ')},	/* Tsonga */
   {"tt",	HB_TAG('T','A','T',' ')},	/* Tatar */
   {"tum",	HB_TAG('T','U','M',' ')},	/* Tumbuka */
+  {"tvl",	HB_TAG('T','V','L',' ')},	/* Tuvalu */
   {"tw",	HB_TAG('T','W','I',' ')},	/* Twi */
   {"ty",	HB_TAG('T','H','T',' ')},	/* Tahitian */
   {"tyv",	HB_TAG('T','U','V',' ')},	/* Tuvin */
   {"tyz",	HB_TAG('T','Y','Z',' ')},	/* Tày */
   {"tzm",	HB_TAG('T','Z','M',' ')},	/* Central Atlas Tamazight */
+  {"tzo",	HB_TAG('T','Z','O',' ')},	/* Tzotzil */
   {"udm",	HB_TAG('U','D','M',' ')},	/* Udmurt */
   {"ug",	HB_TAG('U','Y','G',' ')},	/* Uighur */
   {"uk",	HB_TAG('U','K','R',' ')},	/* Ukrainian */
@@ -688,10 +744,10 @@ static const LangTag ot_languages[] = {
   {"uz",	HB_TAG('U','Z','B',' ')},	/* Uzbek [macrolanguage] */
   {"uzn",	HB_TAG('U','Z','B',' ')},	/* Northern Uzbek */
   {"uzs",	HB_TAG('U','Z','B',' ')},	/* Southern Uzbek */
-  {"ve",	HB_TAG('V','E','N',' ')},	/* Venda */
   {"vec",	HB_TAG('V','E','C',' ')},	/* Venetian */
-  {"vls",	HB_TAG('F','L','E',' ')},	/* Vlaams */
+  {"ve",	HB_TAG('V','E','N',' ')},	/* Venda */
   {"vi",	HB_TAG('V','I','T',' ')},	/* Vietnamese */
+  {"vls",	HB_TAG('F','L','E',' ')},	/* Vlaams */
   {"vmw",	HB_TAG('M','A','K',' ')},	/* Makhuwa */
   {"vo",	HB_TAG('V','O','L',' ')},	/* Volapük */
   {"vro",	HB_TAG('V','R','O',' ')},	/* Võro */
@@ -700,25 +756,30 @@ static const LangTag ot_languages[] = {
   {"wbm",	HB_TAG('W','A',' ',' ')},	/* Wa */
   {"wbr",	HB_TAG('W','A','G',' ')},	/* Wagdi */
   {"wle",	HB_TAG('S','I','G',' ')},	/* Wolane */
+  {"wo",	HB_TAG('W','L','F',' ')},	/* Wolof */
   {"wry",	HB_TAG('M','A','W',' ')},	/* Merwari */
   {"wtm",	HB_TAG('W','T','M',' ')},	/* Mewati */
-  {"wo",	HB_TAG('W','L','F',' ')},	/* Wolof */
   {"xal",	HB_TAG('K','L','M',' ')},	/* Kalmyk */
   {"xh",	HB_TAG('X','H','S',' ')},	/* Xhosa */
+  {"xjb",	HB_TAG('X','J','B',' ')},	/* Minjangbal */
   {"xog",	HB_TAG('X','O','G',' ')},	/* Soga */
   {"xom",	HB_TAG('K','M','O',' ')},	/* Komo (Sudan) */
+  {"xpe",	HB_TAG('X','P','E',' ')},	/* Kpelle (Liberia) */
   {"xsl",	HB_TAG('S','S','L',' ')},	/* South Slavey */
   {"xst",	HB_TAG('S','I','G',' ')},	/* Silt'e (retired code) */
   {"xwo",	HB_TAG('T','O','D',' ')},	/* Written Oirat (Todo) */
   {"yao",	HB_TAG('Y','A','O',' ')},	/* Yao */
+  {"yap",	HB_TAG('Y','A','P',' ')},	/* Yapese */
   {"yi",	HB_TAG('J','I','I',' ')},	/* Yiddish [macrolanguage] */
   {"yo",	HB_TAG('Y','B','A',' ')},	/* Yoruba */
   {"yso",	HB_TAG('N','I','S',' ')},	/* Nisi (China) */
   {"za",	HB_TAG('Z','H','A',' ')},	/* Chuang/Zhuang [macrolanguage] */
   {"zea",	HB_TAG('Z','E','A',' ')},	/* Zeeuws */
+  {"zgh",	HB_TAG('Z','G','H',' ')},	/* Standard Morrocan Tamazigh */
   {"zne",	HB_TAG('Z','N','D',' ')},	/* Zande */
   {"zu",	HB_TAG('Z','U','L',' ')}, 	/* Zulu */
   {"zum",	HB_TAG('L','R','C',' ')}	/* Kumzari */
+  {"zza",	HB_TAG('Z','Z','A',' ')},	/* Zazaki */
 
   /* The corresponding languages IDs for the following IDs are unclear,
    * overlap, or are architecturally weird. Needs more research. */


### PR DESCRIPTION
Synchronised with OpenType 1.7, and suggested some more changes for “difficult“ tags.