### PR TITLE
Add braces for subobject initializer in _hb_font_funcs_nil

### DIFF
--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -297,9 +297,11 @@ static const hb_font_funcs_t _hb_font_funcs_nil = {
 #undef HB_FONT_FUNC_IMPLEMENT
   },
   {
+    {
 #define HB_FONT_FUNC_IMPLEMENT(name) hb_font_get_##name##_nil,
-    HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
+      HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
+    }
   }
 };
 static const hb_font_funcs_t _hb_font_funcs_parent = {
@@ -318,9 +320,11 @@ static const hb_font_funcs_t _hb_font_funcs_parent = {
 #undef HB_FONT_FUNC_IMPLEMENT
   },
   {
+    {
 #define HB_FONT_FUNC_IMPLEMENT(name) hb_font_get_##name##_parent,
-    HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
+      HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
+    }
   }
 };
 


### PR DESCRIPTION
To avoid triggering -Wmissing-braces; see https://bugzilla.mozilla.org/show_bug.cgi?id=1226175#c8