### PR TITLE
Enable use of compiler directives to export symbols

### DIFF
--- a/src/hb-blob.h
+++ b/src/hb-blob.h
@@ -64,7 +64,7 @@ typedef enum {
 
 typedef struct hb_blob_t hb_blob_t;
 
-hb_blob_t *
+HB_EXTERN hb_blob_t *
 hb_blob_create (const char        *data,
 		unsigned int       length,
 		hb_memory_mode_t   mode,
@@ -77,21 +77,21 @@ hb_blob_create (const char        *data,
  * modify the parent data as that data may be
  * shared among multiple sub-blobs.
  */
-hb_blob_t *
+HB_EXTERN hb_blob_t *
 hb_blob_create_sub_blob (hb_blob_t    *parent,
 			 unsigned int  offset,
 			 unsigned int  length);
 
-hb_blob_t *
+HB_EXTERN hb_blob_t *
 hb_blob_get_empty (void);
 
-hb_blob_t *
+HB_EXTERN hb_blob_t *
 hb_blob_reference (hb_blob_t *blob);
 
-void
+HB_EXTERN void
 hb_blob_destroy (hb_blob_t *blob);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_blob_set_user_data (hb_blob_t          *blob,
 		       hb_user_data_key_t *key,
 		       void *              data,
@@ -99,25 +99,25 @@ hb_blob_set_user_data (hb_blob_t          *blob,
 		       hb_bool_t           replace);
 
 
-void *
+HB_EXTERN void *
 hb_blob_get_user_data (hb_blob_t          *blob,
 		       hb_user_data_key_t *key);
 
 
-void
+HB_EXTERN void
 hb_blob_make_immutable (hb_blob_t *blob);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_blob_is_immutable (hb_blob_t *blob);
 
 
-unsigned int
+HB_EXTERN unsigned int
 hb_blob_get_length (hb_blob_t *blob);
 
-const char *
+HB_EXTERN const char *
 hb_blob_get_data (hb_blob_t *blob, unsigned int *length);
 
-char *
+HB_EXTERN char *
 hb_blob_get_data_writable (hb_blob_t *blob, unsigned int *length);
 
 

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -77,11 +77,11 @@ typedef struct hb_segment_properties_t {
 				       NULL, \
 				       NULL}
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_segment_properties_equal (const hb_segment_properties_t *a,
 			     const hb_segment_properties_t *b);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_segment_properties_hash (const hb_segment_properties_t *p);
 
 
@@ -92,26 +92,26 @@ hb_segment_properties_hash (const hb_segment_properties_t *p);
 
 typedef struct hb_buffer_t hb_buffer_t;
 
-hb_buffer_t *
+HB_EXTERN hb_buffer_t *
 hb_buffer_create (void);
 
-hb_buffer_t *
+HB_EXTERN hb_buffer_t *
 hb_buffer_get_empty (void);
 
-hb_buffer_t *
+HB_EXTERN hb_buffer_t *
 hb_buffer_reference (hb_buffer_t *buffer);
 
-void
+HB_EXTERN void
 hb_buffer_destroy (hb_buffer_t *buffer);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_buffer_set_user_data (hb_buffer_t        *buffer,
 			 hb_user_data_key_t *key,
 			 void *              data,
 			 hb_destroy_func_t   destroy,
 			 hb_bool_t           replace);
 
-void *
+HB_EXTERN void *
 hb_buffer_get_user_data (hb_buffer_t        *buffer,
 			 hb_user_data_key_t *key);
 
@@ -122,52 +122,52 @@ typedef enum {
   HB_BUFFER_CONTENT_TYPE_GLYPHS
 } hb_buffer_content_type_t;
 
-void
+HB_EXTERN void
 hb_buffer_set_content_type (hb_buffer_t              *buffer,
 			    hb_buffer_content_type_t  content_type);
 
-hb_buffer_content_type_t
+HB_EXTERN hb_buffer_content_type_t
 hb_buffer_get_content_type (hb_buffer_t *buffer);
 
 
-void
+HB_EXTERN void
 hb_buffer_set_unicode_funcs (hb_buffer_t        *buffer,
 			     hb_unicode_funcs_t *unicode_funcs);
 
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_buffer_get_unicode_funcs (hb_buffer_t        *buffer);
 
-void
+HB_EXTERN void
 hb_buffer_set_direction (hb_buffer_t    *buffer,
 			 hb_direction_t  direction);
 
-hb_direction_t
+HB_EXTERN hb_direction_t
 hb_buffer_get_direction (hb_buffer_t *buffer);
 
-void
+HB_EXTERN void
 hb_buffer_set_script (hb_buffer_t *buffer,
 		      hb_script_t  script);
 
-hb_script_t
+HB_EXTERN hb_script_t
 hb_buffer_get_script (hb_buffer_t *buffer);
 
-void
+HB_EXTERN void
 hb_buffer_set_language (hb_buffer_t   *buffer,
 			hb_language_t  language);
 
 
-hb_language_t
+HB_EXTERN hb_language_t
 hb_buffer_get_language (hb_buffer_t *buffer);
 
-void
+HB_EXTERN void
 hb_buffer_set_segment_properties (hb_buffer_t *buffer,
 				  const hb_segment_properties_t *props);
 
-void
+HB_EXTERN void
 hb_buffer_get_segment_properties (hb_buffer_t *buffer,
 				  hb_segment_properties_t *props);
 
-void
+HB_EXTERN void
 hb_buffer_guess_segment_properties (hb_buffer_t *buffer);
 
 
@@ -181,11 +181,11 @@ typedef enum { /*< flags >*/
   HB_BUFFER_FLAG_PRESERVE_DEFAULT_IGNORABLES	= 0x00000004u
 } hb_buffer_flags_t;
 
-void
+HB_EXTERN void
 hb_buffer_set_flags (hb_buffer_t       *buffer,
 		     hb_buffer_flags_t  flags);
 
-hb_buffer_flags_t
+HB_EXTERN hb_buffer_flags_t
 hb_buffer_get_flags (hb_buffer_t *buffer);
 
 /*
@@ -198,77 +198,77 @@ typedef enum {
   HB_BUFFER_CLUSTER_LEVEL_DEFAULT = HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES
 } hb_buffer_cluster_level_t;
 
-void
+HB_EXTERN void
 hb_buffer_set_cluster_level (hb_buffer_t               *buffer,
 			     hb_buffer_cluster_level_t  cluster_level);
 
-hb_buffer_cluster_level_t
+HB_EXTERN hb_buffer_cluster_level_t
 hb_buffer_get_cluster_level (hb_buffer_t *buffer);
 
 #define HB_BUFFER_REPLACEMENT_CODEPOINT_DEFAULT 0xFFFDu
 
 /* Sets codepoint used to replace invalid UTF-8/16/32 entries.
  * Default is 0xFFFDu. */
-void
+HB_EXTERN void
 hb_buffer_set_replacement_codepoint (hb_buffer_t    *buffer,
 				     hb_codepoint_t  replacement);
 
-hb_codepoint_t
+HB_EXTERN hb_codepoint_t
 hb_buffer_get_replacement_codepoint (hb_buffer_t    *buffer);
 
 
 /* Resets the buffer.  Afterwards it's as if it was just created,
  * except that it has a larger buffer allocated perhaps... */
-void
+HB_EXTERN void
 hb_buffer_reset (hb_buffer_t *buffer);
 
 /* Like reset, but does NOT clear unicode_funcs and replacement_codepoint. */
-void
+HB_EXTERN void
 hb_buffer_clear_contents (hb_buffer_t *buffer);
 
 /* Returns false if allocation failed */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_buffer_pre_allocate (hb_buffer_t  *buffer,
 		        unsigned int  size);
 
 
 /* Returns false if allocation has failed before */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_buffer_allocation_successful (hb_buffer_t  *buffer);
 
-void
+HB_EXTERN void
 hb_buffer_reverse (hb_buffer_t *buffer);
 
-void
+HB_EXTERN void
 hb_buffer_reverse_range (hb_buffer_t *buffer,
 			 unsigned int start, unsigned int end);
 
-void
+HB_EXTERN void
 hb_buffer_reverse_clusters (hb_buffer_t *buffer);
 
 
 /* Filling the buffer in */
 
-void
+HB_EXTERN void
 hb_buffer_add (hb_buffer_t    *buffer,
 	       hb_codepoint_t  codepoint,
 	       unsigned int    cluster);
 
-void
+HB_EXTERN void
 hb_buffer_add_utf8 (hb_buffer_t  *buffer,
 		    const char   *text,
 		    int           text_length,
 		    unsigned int  item_offset,
 		    int           item_length);
 
-void
+HB_EXTERN void
 hb_buffer_add_utf16 (hb_buffer_t    *buffer,
 		     const uint16_t *text,
 		     int             text_length,
 		     unsigned int    item_offset,
 		     int             item_length);
 
-void
+HB_EXTERN void
 hb_buffer_add_utf32 (hb_buffer_t    *buffer,
 		     const uint32_t *text,
 		     int             text_length,
@@ -276,7 +276,7 @@ hb_buffer_add_utf32 (hb_buffer_t    *buffer,
 		     int             item_length);
 
 /* Allows only access to first 256 Unicode codepoints. */
-void
+HB_EXTERN void
 hb_buffer_add_latin1 (hb_buffer_t   *buffer,
 		      const uint8_t *text,
 		      int            text_length,
@@ -284,7 +284,7 @@ hb_buffer_add_latin1 (hb_buffer_t   *buffer,
 		      int            item_length);
 
 /* Like add_utf32 but does NOT check for invalid Unicode codepoints. */
-void
+HB_EXTERN void
 hb_buffer_add_codepoints (hb_buffer_t          *buffer,
 			  const hb_codepoint_t *text,
 			  int                   text_length,
@@ -293,23 +293,23 @@ hb_buffer_add_codepoints (hb_buffer_t          *buffer,
 
 
 /* Clears any new items added at the end */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_buffer_set_length (hb_buffer_t  *buffer,
 		      unsigned int  length);
 
 /* Return value valid as long as buffer not modified */
-unsigned int
+HB_EXTERN unsigned int
 hb_buffer_get_length (hb_buffer_t *buffer);
 
 /* Getting glyphs out of the buffer */
 
 /* Return value valid as long as buffer not modified */
-hb_glyph_info_t *
+HB_EXTERN hb_glyph_info_t *
 hb_buffer_get_glyph_infos (hb_buffer_t  *buffer,
                            unsigned int *length);
 
 /* Return value valid as long as buffer not modified */
-hb_glyph_position_t *
+HB_EXTERN hb_glyph_position_t *
 hb_buffer_get_glyph_positions (hb_buffer_t  *buffer,
                                unsigned int *length);
 
@@ -317,7 +317,7 @@ hb_buffer_get_glyph_positions (hb_buffer_t  *buffer,
 /* Reorders a glyph buffer to have canonical in-cluster glyph order / position.
  * The resulting clusters should behave identical to pre-reordering clusters.
  * NOTE: This has nothing to do with Unicode normalization. */
-void
+HB_EXTERN void
 hb_buffer_normalize_glyphs (hb_buffer_t *buffer);
 
 
@@ -343,17 +343,17 @@ typedef enum {
 } hb_buffer_serialize_format_t;
 
 /* len=-1 means str is NUL-terminated. */
-hb_buffer_serialize_format_t
+HB_EXTERN hb_buffer_serialize_format_t
 hb_buffer_serialize_format_from_string (const char *str, int len);
 
-const char *
+HB_EXTERN const char *
 hb_buffer_serialize_format_to_string (hb_buffer_serialize_format_t format);
 
-const char **
+HB_EXTERN const char **
 hb_buffer_serialize_list_formats (void);
 
 /* Returns number of items, starting at start, that were serialized. */
-unsigned int
+HB_EXTERN unsigned int
 hb_buffer_serialize_glyphs (hb_buffer_t *buffer,
 			    unsigned int start,
 			    unsigned int end,
@@ -364,7 +364,7 @@ hb_buffer_serialize_glyphs (hb_buffer_t *buffer,
 			    hb_buffer_serialize_format_t format,
 			    hb_buffer_serialize_flags_t flags);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_buffer_deserialize_glyphs (hb_buffer_t *buffer,
 			      const char *buf,
 			      int buf_len, /* -1 means nul-terminated */

--- a/src/hb-common.h
+++ b/src/hb-common.h
@@ -98,11 +98,11 @@ typedef uint32_t hb_tag_t;
 #define HB_TAG_MAX_SIGNED HB_TAG(0x7f,0xff,0xff,0xff)
 
 /* len=-1 means str is NUL-terminated. */
-hb_tag_t
+HB_EXTERN hb_tag_t
 hb_tag_from_string (const char *str, int len);
 
 /* buf should have 4 bytes. */
-void
+HB_EXTERN void
 hb_tag_to_string (hb_tag_t tag, char *buf);
 
 
@@ -117,10 +117,10 @@ typedef enum {
 } hb_direction_t;
 
 /* len=-1 means str is NUL-terminated */
-hb_direction_t
+HB_EXTERN hb_direction_t
 hb_direction_from_string (const char *str, int len);
 
-const char *
+HB_EXTERN const char *
 hb_direction_to_string (hb_direction_t direction);
 
 #define HB_DIRECTION_IS_VALID(dir)	((((unsigned int) (dir)) & ~3U) == 4)
@@ -137,15 +137,15 @@ hb_direction_to_string (hb_direction_t direction);
 typedef const struct hb_language_impl_t *hb_language_t;
 
 /* len=-1 means str is NUL-terminated */
-hb_language_t
+HB_EXTERN hb_language_t
 hb_language_from_string (const char *str, int len);
 
-const char *
+HB_EXTERN const char *
 hb_language_to_string (hb_language_t language);
 
 #define HB_LANGUAGE_INVALID ((hb_language_t) NULL)
 
-hb_language_t
+HB_EXTERN hb_language_t
 hb_language_get_default (void);
 
 
@@ -324,18 +324,18 @@ typedef enum
 
 /* Script functions */
 
-hb_script_t
+HB_EXTERN hb_script_t
 hb_script_from_iso15924_tag (hb_tag_t tag);
 
 /* sugar for tag_from_string() then script_from_iso15924_tag */
 /* len=-1 means s is NUL-terminated */
-hb_script_t
+HB_EXTERN hb_script_t
 hb_script_from_string (const char *s, int len);
 
-hb_tag_t
+HB_EXTERN hb_tag_t
 hb_script_to_iso15924_tag (hb_script_t script);
 
-hb_direction_t
+HB_EXTERN hb_direction_t
 hb_script_get_horizontal_direction (hb_script_t script);
 
 

--- a/src/hb-coretext.h
+++ b/src/hb-coretext.h
@@ -44,14 +44,14 @@ HB_BEGIN_DECLS
 #define HB_CORETEXT_TAG_MORX HB_TAG('m','o','r','x')
 
 
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_coretext_face_create (CGFontRef cg_font);
 
 
-CGFontRef
+HB_EXTERN CGFontRef
 hb_coretext_face_get_cg_font (hb_face_t *face);
 
-CTFontRef
+HB_EXTERN CTFontRef
 hb_coretext_font_get_ct_font (hb_font_t *font);
 
 

--- a/src/hb-face.h
+++ b/src/hb-face.h
@@ -43,28 +43,28 @@ HB_BEGIN_DECLS
 
 typedef struct hb_face_t hb_face_t;
 
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_face_create (hb_blob_t    *blob,
 		unsigned int  index);
 
 typedef hb_blob_t * (*hb_reference_table_func_t)  (hb_face_t *face, hb_tag_t tag, void *user_data);
 
 /* calls destroy() when not needing user_data anymore */
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_face_create_for_tables (hb_reference_table_func_t  reference_table_func,
 			   void                      *user_data,
 			   hb_destroy_func_t          destroy);
 
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_face_get_empty (void);
 
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_face_reference (hb_face_t *face);
 
-void
+HB_EXTERN void
 hb_face_destroy (hb_face_t *face);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_face_set_user_data (hb_face_t          *face,
 		       hb_user_data_key_t *key,
 		       void *              data,
@@ -72,43 +72,43 @@ hb_face_set_user_data (hb_face_t          *face,
 		       hb_bool_t           replace);
 
 
-void *
+HB_EXTERN void *
 hb_face_get_user_data (hb_face_t          *face,
 		       hb_user_data_key_t *key);
 
-void
+HB_EXTERN void
 hb_face_make_immutable (hb_face_t *face);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_face_is_immutable (hb_face_t *face);
 
 
-hb_blob_t *
+HB_EXTERN hb_blob_t *
 hb_face_reference_table (hb_face_t *face,
 			 hb_tag_t   tag);
 
-hb_blob_t *
+HB_EXTERN hb_blob_t *
 hb_face_reference_blob (hb_face_t *face);
 
-void
+HB_EXTERN void
 hb_face_set_index (hb_face_t    *face,
 		   unsigned int  index);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_face_get_index (hb_face_t    *face);
 
-void
+HB_EXTERN void
 hb_face_set_upem (hb_face_t    *face,
 		  unsigned int  upem);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_face_get_upem (hb_face_t *face);
 
-void
+HB_EXTERN void
 hb_face_set_glyph_count (hb_face_t    *face,
 			 unsigned int  glyph_count);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_face_get_glyph_count (hb_face_t *face);
 
 

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -46,19 +46,19 @@ typedef struct hb_font_t hb_font_t;
 
 typedef struct hb_font_funcs_t hb_font_funcs_t;
 
-hb_font_funcs_t *
+HB_EXTERN hb_font_funcs_t *
 hb_font_funcs_create (void);
 
-hb_font_funcs_t *
+HB_EXTERN hb_font_funcs_t *
 hb_font_funcs_get_empty (void);
 
-hb_font_funcs_t *
+HB_EXTERN hb_font_funcs_t *
 hb_font_funcs_reference (hb_font_funcs_t *ffuncs);
 
-void
+HB_EXTERN void
 hb_font_funcs_destroy (hb_font_funcs_t *ffuncs);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_funcs_set_user_data (hb_font_funcs_t    *ffuncs,
 			     hb_user_data_key_t *key,
 			     void *              data,
@@ -66,15 +66,15 @@ hb_font_funcs_set_user_data (hb_font_funcs_t    *ffuncs,
 			     hb_bool_t           replace);
 
 
-void *
+HB_EXTERN void *
 hb_font_funcs_get_user_data (hb_font_funcs_t    *ffuncs,
 			     hb_user_data_key_t *key);
 
 
-void
+HB_EXTERN void
 hb_font_funcs_make_immutable (hb_font_funcs_t *ffuncs);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_funcs_is_immutable (hb_font_funcs_t *ffuncs);
 
 
@@ -151,7 +151,7 @@ typedef hb_bool_t (*hb_font_get_glyph_from_name_func_t) (hb_font_t *font, void *
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_func (hb_font_funcs_t *ffuncs,
 			      hb_font_get_glyph_func_t func,
 			      void *user_data, hb_destroy_func_t destroy);
@@ -167,7 +167,7 @@ hb_font_funcs_set_glyph_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_h_advance_func (hb_font_funcs_t *ffuncs,
 					hb_font_get_glyph_h_advance_func_t func,
 					void *user_data, hb_destroy_func_t destroy);
@@ -183,7 +183,7 @@ hb_font_funcs_set_glyph_h_advance_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_v_advance_func (hb_font_funcs_t *ffuncs,
 					hb_font_get_glyph_v_advance_func_t func,
 					void *user_data, hb_destroy_func_t destroy);
@@ -199,7 +199,7 @@ hb_font_funcs_set_glyph_v_advance_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_h_origin_func (hb_font_funcs_t *ffuncs,
 				       hb_font_get_glyph_h_origin_func_t func,
 				       void *user_data, hb_destroy_func_t destroy);
@@ -215,7 +215,7 @@ hb_font_funcs_set_glyph_h_origin_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_v_origin_func (hb_font_funcs_t *ffuncs,
 				       hb_font_get_glyph_v_origin_func_t func,
 				       void *user_data, hb_destroy_func_t destroy);
@@ -231,7 +231,7 @@ hb_font_funcs_set_glyph_v_origin_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_h_kerning_func (hb_font_funcs_t *ffuncs,
 					hb_font_get_glyph_h_kerning_func_t func,
 					void *user_data, hb_destroy_func_t destroy);
@@ -247,7 +247,7 @@ hb_font_funcs_set_glyph_h_kerning_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_v_kerning_func (hb_font_funcs_t *ffuncs,
 					hb_font_get_glyph_v_kerning_func_t func,
 					void *user_data, hb_destroy_func_t destroy);
@@ -263,7 +263,7 @@ hb_font_funcs_set_glyph_v_kerning_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_extents_func (hb_font_funcs_t *ffuncs,
 				      hb_font_get_glyph_extents_func_t func,
 				      void *user_data, hb_destroy_func_t destroy);
@@ -279,7 +279,7 @@ hb_font_funcs_set_glyph_extents_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_contour_point_func (hb_font_funcs_t *ffuncs,
 					    hb_font_get_glyph_contour_point_func_t func,
 					    void *user_data, hb_destroy_func_t destroy);
@@ -295,7 +295,7 @@ hb_font_funcs_set_glyph_contour_point_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_name_func (hb_font_funcs_t *ffuncs,
 				   hb_font_get_glyph_name_func_t func,
 				   void *user_data, hb_destroy_func_t destroy);
@@ -311,7 +311,7 @@ hb_font_funcs_set_glyph_name_func (hb_font_funcs_t *ffuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_font_funcs_set_glyph_from_name_func (hb_font_funcs_t *ffuncs,
 					hb_font_get_glyph_from_name_func_t func,
 					void *user_data, hb_destroy_func_t destroy);
@@ -319,49 +319,49 @@ hb_font_funcs_set_glyph_from_name_func (hb_font_funcs_t *ffuncs,
 
 /* func dispatch */
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph (hb_font_t *font,
 		   hb_codepoint_t unicode, hb_codepoint_t variation_selector,
 		   hb_codepoint_t *glyph);
 
-hb_position_t
+HB_EXTERN hb_position_t
 hb_font_get_glyph_h_advance (hb_font_t *font,
 			     hb_codepoint_t glyph);
-hb_position_t
+HB_EXTERN hb_position_t
 hb_font_get_glyph_v_advance (hb_font_t *font,
 			     hb_codepoint_t glyph);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_h_origin (hb_font_t *font,
 			    hb_codepoint_t glyph,
 			    hb_position_t *x, hb_position_t *y);
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_v_origin (hb_font_t *font,
 			    hb_codepoint_t glyph,
 			    hb_position_t *x, hb_position_t *y);
 
-hb_position_t
+HB_EXTERN hb_position_t
 hb_font_get_glyph_h_kerning (hb_font_t *font,
 			     hb_codepoint_t left_glyph, hb_codepoint_t right_glyph);
-hb_position_t
+HB_EXTERN hb_position_t
 hb_font_get_glyph_v_kerning (hb_font_t *font,
 			     hb_codepoint_t top_glyph, hb_codepoint_t bottom_glyph);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_extents (hb_font_t *font,
 			   hb_codepoint_t glyph,
 			   hb_glyph_extents_t *extents);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_contour_point (hb_font_t *font,
 				 hb_codepoint_t glyph, unsigned int point_index,
 				 hb_position_t *x, hb_position_t *y);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_name (hb_font_t *font,
 			hb_codepoint_t glyph,
 			char *name, unsigned int size);
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_from_name (hb_font_t *font,
 			     const char *name, int len, /* -1 means nul-terminated */
 			     hb_codepoint_t *glyph);
@@ -369,52 +369,52 @@ hb_font_get_glyph_from_name (hb_font_t *font,
 
 /* high-level funcs, with fallback */
 
-void
+HB_EXTERN void
 hb_font_get_glyph_advance_for_direction (hb_font_t *font,
 					 hb_codepoint_t glyph,
 					 hb_direction_t direction,
 					 hb_position_t *x, hb_position_t *y);
-void
+HB_EXTERN void
 hb_font_get_glyph_origin_for_direction (hb_font_t *font,
 					hb_codepoint_t glyph,
 					hb_direction_t direction,
 					hb_position_t *x, hb_position_t *y);
-void
+HB_EXTERN void
 hb_font_add_glyph_origin_for_direction (hb_font_t *font,
 					hb_codepoint_t glyph,
 					hb_direction_t direction,
 					hb_position_t *x, hb_position_t *y);
-void
+HB_EXTERN void
 hb_font_subtract_glyph_origin_for_direction (hb_font_t *font,
 					     hb_codepoint_t glyph,
 					     hb_direction_t direction,
 					     hb_position_t *x, hb_position_t *y);
 
-void
+HB_EXTERN void
 hb_font_get_glyph_kerning_for_direction (hb_font_t *font,
 					 hb_codepoint_t first_glyph, hb_codepoint_t second_glyph,
 					 hb_direction_t direction,
 					 hb_position_t *x, hb_position_t *y);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_extents_for_origin (hb_font_t *font,
 				      hb_codepoint_t glyph,
 				      hb_direction_t direction,
 				      hb_glyph_extents_t *extents);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_get_glyph_contour_point_for_origin (hb_font_t *font,
 					    hb_codepoint_t glyph, unsigned int point_index,
 					    hb_direction_t direction,
 					    hb_position_t *x, hb_position_t *y);
 
 /* Generates gidDDD if glyph has no name. */
-void
+HB_EXTERN void
 hb_font_glyph_to_string (hb_font_t *font,
 			 hb_codepoint_t glyph,
 			 char *s, unsigned int size);
 /* Parses gidDDD and uniUUUU strings automatically. */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_glyph_from_string (hb_font_t *font,
 			   const char *s, int len, /* -1 means nul-terminated */
 			   hb_codepoint_t *glyph);
@@ -426,22 +426,22 @@ hb_font_glyph_from_string (hb_font_t *font,
 
 /* Fonts are very light-weight objects */
 
-hb_font_t *
+HB_EXTERN hb_font_t *
 hb_font_create (hb_face_t *face);
 
-hb_font_t *
+HB_EXTERN hb_font_t *
 hb_font_create_sub_font (hb_font_t *parent);
 
-hb_font_t *
+HB_EXTERN hb_font_t *
 hb_font_get_empty (void);
 
-hb_font_t *
+HB_EXTERN hb_font_t *
 hb_font_reference (hb_font_t *font);
 
-void
+HB_EXTERN void
 hb_font_destroy (hb_font_t *font);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_set_user_data (hb_font_t          *font,
 		       hb_user_data_key_t *key,
 		       void *              data,
@@ -449,46 +449,46 @@ hb_font_set_user_data (hb_font_t          *font,
 		       hb_bool_t           replace);
 
 
-void *
+HB_EXTERN void *
 hb_font_get_user_data (hb_font_t          *font,
 		       hb_user_data_key_t *key);
 
-void
+HB_EXTERN void
 hb_font_make_immutable (hb_font_t *font);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_font_is_immutable (hb_font_t *font);
 
-void
+HB_EXTERN void
 hb_font_set_parent (hb_font_t *font,
 		    hb_font_t *parent);
 
-hb_font_t *
+HB_EXTERN hb_font_t *
 hb_font_get_parent (hb_font_t *font);
 
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_font_get_face (hb_font_t *font);
 
 
-void
+HB_EXTERN void
 hb_font_set_funcs (hb_font_t         *font,
 		   hb_font_funcs_t   *klass,
 		   void              *font_data,
 		   hb_destroy_func_t  destroy);
 
 /* Be *very* careful with this function! */
-void
+HB_EXTERN void
 hb_font_set_funcs_data (hb_font_t         *font,
 		        void              *font_data,
 		        hb_destroy_func_t  destroy);
 
 
-void
+HB_EXTERN void
 hb_font_set_scale (hb_font_t *font,
 		   int x_scale,
 		   int y_scale);
 
-void
+HB_EXTERN void
 hb_font_get_scale (hb_font_t *font,
 		   int *x_scale,
 		   int *y_scale);
@@ -496,12 +496,12 @@ hb_font_get_scale (hb_font_t *font,
 /*
  * A zero value means "no hinting in that direction"
  */
-void
+HB_EXTERN void
 hb_font_set_ppem (hb_font_t *font,
 		  unsigned int x_ppem,
 		  unsigned int y_ppem);
 
-void
+HB_EXTERN void
 hb_font_get_ppem (hb_font_t *font,
 		  unsigned int *x_ppem,
 		  unsigned int *y_ppem);

--- a/src/hb-ft.h
+++ b/src/hb-ft.h
@@ -59,7 +59,7 @@ HB_BEGIN_DECLS
  * probably should use (the more recent) hb_ft_face_create_referenced()
  * instead.
  */
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_ft_face_create (FT_Face           ft_face,
 		   hb_destroy_func_t destroy);
 
@@ -71,7 +71,7 @@ hb_ft_face_create (FT_Face           ft_face,
  * Client is still responsible for making sure that ft-face is destroyed
  * after hb-face is.
  */
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_ft_face_create_cached (FT_Face ft_face);
 
 /* This version is like hb_ft_face_create(), except that it calls
@@ -81,7 +81,7 @@ hb_ft_face_create_cached (FT_Face ft_face);
  * This is the most convenient version to use.  Use it unless you have
  * very good reasons not to.
  */
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_ft_face_create_referenced (FT_Face ft_face);
 
 
@@ -98,26 +98,26 @@ hb_ft_face_create_referenced (FT_Face ft_face);
 
 /* See notes on hb_ft_face_create().  Same issues re lifecycle-management
  * apply here.  Use hb_ft_font_create_referenced() if you can. */
-hb_font_t *
+HB_EXTERN hb_font_t *
 hb_ft_font_create (FT_Face           ft_face,
 		   hb_destroy_func_t destroy);
 
 /* See notes on hb_ft_face_create_referenced() re lifecycle-management
  * issues. */
-hb_font_t *
+HB_EXTERN hb_font_t *
 hb_ft_font_create_referenced (FT_Face ft_face);
 
-FT_Face
+HB_EXTERN FT_Face
 hb_ft_font_get_face (hb_font_t *font);
 
-void
+HB_EXTERN void
 hb_ft_font_set_load_flags (hb_font_t *font, int load_flags);
 
-int
+HB_EXTERN int
 hb_ft_font_get_load_flags (hb_font_t *font);
 
 /* Makes an hb_font_t use FreeType internally to implement font functions. */
-void
+HB_EXTERN void
 hb_ft_font_set_funcs (hb_font_t *font);
 
 

--- a/src/hb-glib.h
+++ b/src/hb-glib.h
@@ -36,17 +36,17 @@
 HB_BEGIN_DECLS
 
 
-hb_script_t
+HB_EXTERN hb_script_t
 hb_glib_script_to_script (GUnicodeScript script);
 
-GUnicodeScript
+HB_EXTERN GUnicodeScript
 hb_glib_script_from_script (hb_script_t script);
 
 
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_glib_get_unicode_funcs (void);
 
-hb_blob_t *
+HB_EXTERN hb_blob_t *
 hb_glib_blob_create (GBytes *gbytes);
 
 

--- a/src/hb-gobject-enums.h.tmpl
+++ b/src/hb-gobject-enums.h.tmpl
@@ -42,7 +42,7 @@ HB_BEGIN_DECLS
 /*** END file-header ***/
 
 /*** BEGIN value-header ***/
-GType @enum_name@_get_type (void) G_GNUC_CONST;
+HB_EXTERN GType @enum_name@_get_type (void) G_GNUC_CONST;
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
 
 /*** END value-header ***/

--- a/src/hb-gobject-structs.h
+++ b/src/hb-gobject-structs.h
@@ -43,60 +43,60 @@ HB_BEGIN_DECLS
 /**
  * Since: 0.9.2
  **/
-GType hb_gobject_blob_get_type (void);
+HB_EXTERN GType hb_gobject_blob_get_type (void);
 #define HB_GOBJECT_TYPE_BLOB (hb_gobject_blob_get_type ())
 
 /**
  * Since: 0.9.2
  **/
-GType hb_gobject_buffer_get_type (void);
+HB_EXTERN GType hb_gobject_buffer_get_type (void);
 #define HB_GOBJECT_TYPE_BUFFER (hb_gobject_buffer_get_type ())
 
 /**
  * Since: 0.9.2
  **/
-GType hb_gobject_face_get_type (void);
+HB_EXTERN GType hb_gobject_face_get_type (void);
 #define HB_GOBJECT_TYPE_FACE (hb_gobject_face_get_type ())
 
 /**
  * Since: 0.9.2
  **/
-GType hb_gobject_font_get_type (void);
+HB_EXTERN GType hb_gobject_font_get_type (void);
 #define HB_GOBJECT_TYPE_FONT (hb_gobject_font_get_type ())
 
 /**
  * Since: 0.9.2
  **/
-GType hb_gobject_font_funcs_get_type (void);
+HB_EXTERN GType hb_gobject_font_funcs_get_type (void);
 #define HB_GOBJECT_TYPE_FONT_FUNCS (hb_gobject_font_funcs_get_type ())
 
-GType hb_gobject_set_get_type (void);
+HB_EXTERN GType hb_gobject_set_get_type (void);
 #define HB_GOBJECT_TYPE_SET (hb_gobject_set_get_type ())
 
-GType hb_gobject_shape_plan_get_type (void);
+HB_EXTERN GType hb_gobject_shape_plan_get_type (void);
 #define HB_GOBJECT_TYPE_SHAPE_PLAN (hb_gobject_shape_plan_get_type ())
 
 /**
  * Since: 0.9.2
  **/
-GType hb_gobject_unicode_funcs_get_type (void);
+HB_EXTERN GType hb_gobject_unicode_funcs_get_type (void);
 #define HB_GOBJECT_TYPE_UNICODE_FUNCS (hb_gobject_unicode_funcs_get_type ())
 
 /* Value types */
 
-GType hb_gobject_feature_get_type (void);
+HB_EXTERN GType hb_gobject_feature_get_type (void);
 #define HB_GOBJECT_TYPE_FEATURE (hb_gobject_feature_get_type ())
 
-GType hb_gobject_glyph_info_get_type (void);
+HB_EXTERN GType hb_gobject_glyph_info_get_type (void);
 #define HB_GOBJECT_TYPE_GLYPH_INFO (hb_gobject_glyph_info_get_type ())
 
-GType hb_gobject_glyph_position_get_type (void);
+HB_EXTERN GType hb_gobject_glyph_position_get_type (void);
 #define HB_GOBJECT_TYPE_GLYPH_POSITION (hb_gobject_glyph_position_get_type ())
 
-GType hb_gobject_segment_properties_get_type (void);
+HB_EXTERN GType hb_gobject_segment_properties_get_type (void);
 #define HB_GOBJECT_TYPE_SEGMENT_PROPERTIES (hb_gobject_segment_properties_get_type ())
 
-GType hb_gobject_user_data_key_get_type (void);
+HB_EXTERN GType hb_gobject_user_data_key_get_type (void);
 #define HB_GOBJECT_TYPE_USER_DATA_KEY (hb_gobject_user_data_key_get_type ())
 
 

--- a/src/hb-graphite2.h
+++ b/src/hb-graphite2.h
@@ -36,10 +36,10 @@ HB_BEGIN_DECLS
 #define HB_GRAPHITE2_TAG_SILF HB_TAG('S','i','l','f')
 
 
-gr_face *
+HB_EXTERN gr_face *
 hb_graphite2_face_get_gr_face (hb_face_t *face);
 
-gr_font *
+HB_EXTERN gr_font *
 hb_graphite2_font_get_gr_font (hb_font_t *font);
 
 

--- a/src/hb-icu.h
+++ b/src/hb-icu.h
@@ -36,14 +36,14 @@
 HB_BEGIN_DECLS
 
 
-hb_script_t
+HB_EXTERN hb_script_t
 hb_icu_script_to_script (UScriptCode script);
 
-UScriptCode
+HB_EXTERN UScriptCode
 hb_icu_script_from_script (hb_script_t script);
 
 
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_icu_get_unicode_funcs (void);
 
 

--- a/src/hb-ot-font.h
+++ b/src/hb-ot-font.h
@@ -36,7 +36,7 @@
 HB_BEGIN_DECLS
 
 
-void
+HB_EXTERN void
 hb_ot_font_set_funcs (hb_font_t *font);
 
 

--- a/src/hb-ot-layout.h
+++ b/src/hb-ot-layout.h
@@ -48,7 +48,7 @@ HB_BEGIN_DECLS
  * GDEF
  */
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_has_glyph_classes (hb_face_t *face);
 
 typedef enum {
@@ -59,11 +59,11 @@ typedef enum {
   HB_OT_LAYOUT_GLYPH_CLASS_COMPONENT	= 4
 } hb_ot_layout_glyph_class_t;
 
-hb_ot_layout_glyph_class_t
+HB_EXTERN hb_ot_layout_glyph_class_t
 hb_ot_layout_get_glyph_class (hb_face_t      *face,
 			      hb_codepoint_t  glyph);
 
-void
+HB_EXTERN void
 hb_ot_layout_get_glyphs_in_class (hb_face_t                  *face,
 				  hb_ot_layout_glyph_class_t  klass,
 				  hb_set_t                   *glyphs /* OUT */);
@@ -71,7 +71,7 @@ hb_ot_layout_get_glyphs_in_class (hb_face_t                  *face,
 
 /* Not that useful.  Provides list of attach points for a glyph that a
  * client may want to cache */
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_get_attach_points (hb_face_t      *face,
 				hb_codepoint_t  glyph,
 				unsigned int    start_offset,
@@ -79,7 +79,7 @@ hb_ot_layout_get_attach_points (hb_face_t      *face,
 				unsigned int   *point_array /* OUT */);
 
 /* Ligature caret positions */
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_get_ligature_carets (hb_font_t      *font,
 				  hb_direction_t  direction,
 				  hb_codepoint_t  glyph,
@@ -96,35 +96,35 @@ hb_ot_layout_get_ligature_carets (hb_font_t      *font,
 #define HB_OT_LAYOUT_NO_FEATURE_INDEX		0xFFFFu
 #define HB_OT_LAYOUT_DEFAULT_LANGUAGE_INDEX	0xFFFFu
 
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_table_get_script_tags (hb_face_t    *face,
 				    hb_tag_t      table_tag,
 				    unsigned int  start_offset,
 				    unsigned int *script_count /* IN/OUT */,
 				    hb_tag_t     *script_tags /* OUT */);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_table_find_script (hb_face_t    *face,
 				hb_tag_t      table_tag,
 				hb_tag_t      script_tag,
 				unsigned int *script_index);
 
 /* Like find_script, but takes zero-terminated array of scripts to test */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_table_choose_script (hb_face_t      *face,
 				  hb_tag_t        table_tag,
 				  const hb_tag_t *script_tags,
 				  unsigned int   *script_index,
 				  hb_tag_t       *chosen_script);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_table_get_feature_tags (hb_face_t    *face,
 				     hb_tag_t      table_tag,
 				     unsigned int  start_offset,
 				     unsigned int *feature_count /* IN/OUT */,
 				     hb_tag_t     *feature_tags /* OUT */);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_script_get_language_tags (hb_face_t    *face,
 				       hb_tag_t      table_tag,
 				       unsigned int  script_index,
@@ -132,21 +132,21 @@ hb_ot_layout_script_get_language_tags (hb_face_t    *face,
 				       unsigned int *language_count /* IN/OUT */,
 				       hb_tag_t     *language_tags /* OUT */);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_script_find_language (hb_face_t    *face,
 				   hb_tag_t      table_tag,
 				   unsigned int  script_index,
 				   hb_tag_t      language_tag,
 				   unsigned int *language_index);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_language_get_required_feature_index (hb_face_t    *face,
 						  hb_tag_t      table_tag,
 						  unsigned int  script_index,
 						  unsigned int  language_index,
 						  unsigned int *feature_index);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_language_get_required_feature (hb_face_t    *face,
 					    hb_tag_t      table_tag,
 					    unsigned int  script_index,
@@ -154,7 +154,7 @@ hb_ot_layout_language_get_required_feature (hb_face_t    *face,
 					    unsigned int *feature_index,
 					    hb_tag_t     *feature_tag);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_language_get_feature_indexes (hb_face_t    *face,
 					   hb_tag_t      table_tag,
 					   unsigned int  script_index,
@@ -163,7 +163,7 @@ hb_ot_layout_language_get_feature_indexes (hb_face_t    *face,
 					   unsigned int *feature_count /* IN/OUT */,
 					   unsigned int *feature_indexes /* OUT */);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_language_get_feature_tags (hb_face_t    *face,
 					hb_tag_t      table_tag,
 					unsigned int  script_index,
@@ -172,7 +172,7 @@ hb_ot_layout_language_get_feature_tags (hb_face_t    *face,
 					unsigned int *feature_count /* IN/OUT */,
 					hb_tag_t     *feature_tags /* OUT */);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_language_find_feature (hb_face_t    *face,
 				    hb_tag_t      table_tag,
 				    unsigned int  script_index,
@@ -180,7 +180,7 @@ hb_ot_layout_language_find_feature (hb_face_t    *face,
 				    hb_tag_t      feature_tag,
 				    unsigned int *feature_index);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_feature_get_lookups (hb_face_t    *face,
 				  hb_tag_t      table_tag,
 				  unsigned int  feature_index,
@@ -188,12 +188,12 @@ hb_ot_layout_feature_get_lookups (hb_face_t    *face,
 				  unsigned int *lookup_count /* IN/OUT */,
 				  unsigned int *lookup_indexes /* OUT */);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_ot_layout_table_get_lookup_count (hb_face_t    *face,
 				     hb_tag_t      table_tag);
 
 
-void
+HB_EXTERN void
 hb_ot_layout_collect_lookups (hb_face_t      *face,
 			      hb_tag_t        table_tag,
 			      const hb_tag_t *scripts,
@@ -201,7 +201,7 @@ hb_ot_layout_collect_lookups (hb_face_t      *face,
 			      const hb_tag_t *features,
 			      hb_set_t       *lookup_indexes /* OUT */);
 
-void
+HB_EXTERN void
 hb_ot_layout_lookup_collect_glyphs (hb_face_t    *face,
 				    hb_tag_t      table_tag,
 				    unsigned int  lookup_index,
@@ -228,7 +228,7 @@ typedef hb_bool_t
 				       const hb_ot_layout_glyph_sequence_t *sequence,
 				       void         *user_data);
 
-void
+HB_EXTERN void
 Xhb_ot_layout_lookup_enumerate_sequences (hb_face_t    *face,
 					 hb_tag_t      table_tag,
 					 unsigned int  lookup_index,
@@ -241,17 +241,17 @@ Xhb_ot_layout_lookup_enumerate_sequences (hb_face_t    *face,
  * GSUB
  */
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_has_substitution (hb_face_t *face);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_lookup_would_substitute (hb_face_t            *face,
 				      unsigned int          lookup_index,
 				      const hb_codepoint_t *glyphs,
 				      unsigned int          glyphs_length,
 				      hb_bool_t             zero_context);
 
-void
+HB_EXTERN void
 hb_ot_layout_lookup_substitute_closure (hb_face_t    *face,
 				        unsigned int  lookup_index,
 				        hb_set_t     *glyphs
@@ -259,7 +259,7 @@ hb_ot_layout_lookup_substitute_closure (hb_face_t    *face,
 
 #ifdef HB_NOT_IMPLEMENTED
 /* Note: You better have GDEF when using this API, or marks won't do much. */
-hb_bool_t
+HB_EXTERN hb_bool_t
 Xhb_ot_layout_lookup_substitute (hb_font_t            *font,
 				unsigned int          lookup_index,
 				const hb_ot_layout_glyph_sequence_t *sequence,
@@ -274,12 +274,12 @@ Xhb_ot_layout_lookup_substitute (hb_font_t            *font,
  * GPOS
  */
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_has_positioning (hb_face_t *face);
 
 #ifdef HB_NOT_IMPLEMENTED
 /* Note: You better have GDEF when using this API, or marks won't do much. */
-hb_bool_t
+HB_EXTERN hb_bool_t
 Xhb_ot_layout_lookup_position (hb_font_t            *font,
 			      unsigned int          lookup_index,
 			      const hb_ot_layout_glyph_sequence_t *sequence,
@@ -288,7 +288,7 @@ Xhb_ot_layout_lookup_position (hb_font_t            *font,
 
 /* Optical 'size' feature info.  Returns true if found.
  * http://www.microsoft.com/typography/otspec/features_pt.htm#size */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_ot_layout_get_size_params (hb_face_t    *face,
 			      unsigned int *design_size,       /* OUT.  May be NULL */
 			      unsigned int *subfamily_id,      /* OUT.  May be NULL */

--- a/src/hb-ot-shape.h
+++ b/src/hb-ot-shape.h
@@ -36,14 +36,14 @@
 HB_BEGIN_DECLS
 
 /* TODO port to shape-plan / set. */
-void
+HB_EXTERN void
 hb_ot_shape_glyphs_closure (hb_font_t          *font,
 			    hb_buffer_t        *buffer,
 			    const hb_feature_t *features,
 			    unsigned int        num_features,
 			    hb_set_t           *glyphs);
 
-void
+HB_EXTERN void
 hb_ot_shape_plan_collect_lookups (hb_shape_plan_t *shape_plan,
 				  hb_tag_t         table_tag,
 				  hb_set_t        *lookup_indexes /* OUT */);

--- a/src/hb-ot-tag.h
+++ b/src/hb-ot-tag.h
@@ -39,18 +39,18 @@ HB_BEGIN_DECLS
 #define HB_OT_TAG_DEFAULT_SCRIPT	HB_TAG ('D', 'F', 'L', 'T')
 #define HB_OT_TAG_DEFAULT_LANGUAGE	HB_TAG ('d', 'f', 'l', 't')
 
-void
+HB_EXTERN void
 hb_ot_tags_from_script (hb_script_t  script,
 			hb_tag_t    *script_tag_1,
 			hb_tag_t    *script_tag_2);
 
-hb_script_t
+HB_EXTERN hb_script_t
 hb_ot_tag_to_script (hb_tag_t tag);
 
-hb_tag_t
+HB_EXTERN hb_tag_t
 hb_ot_tag_from_language (hb_language_t language);
 
-hb_language_t
+HB_EXTERN hb_language_t
 hb_ot_tag_to_language (hb_tag_t tag);
 
 

--- a/src/hb-set.h
+++ b/src/hb-set.h
@@ -44,109 +44,109 @@ HB_BEGIN_DECLS
 typedef struct hb_set_t hb_set_t;
 
 
-hb_set_t *
+HB_EXTERN hb_set_t *
 hb_set_create (void);
 
-hb_set_t *
+HB_EXTERN hb_set_t *
 hb_set_get_empty (void);
 
-hb_set_t *
+HB_EXTERN hb_set_t *
 hb_set_reference (hb_set_t *set);
 
-void
+HB_EXTERN void
 hb_set_destroy (hb_set_t *set);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_set_set_user_data (hb_set_t           *set,
 		      hb_user_data_key_t *key,
 		      void *              data,
 		      hb_destroy_func_t   destroy,
 		      hb_bool_t           replace);
 
-void *
+HB_EXTERN void *
 hb_set_get_user_data (hb_set_t           *set,
 		      hb_user_data_key_t *key);
 
 
 /* Returns false if allocation has failed before */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_set_allocation_successful (const hb_set_t *set);
 
-void
+HB_EXTERN void
 hb_set_clear (hb_set_t *set);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_set_is_empty (const hb_set_t *set);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_set_has (const hb_set_t *set,
 	    hb_codepoint_t  codepoint);
 
 /* Right now limited to 16-bit integers.  Eventually will do full codepoint range, sans -1
  * which we will use as a sentinel. */
-void
+HB_EXTERN void
 hb_set_add (hb_set_t       *set,
 	    hb_codepoint_t  codepoint);
 
-void
+HB_EXTERN void
 hb_set_add_range (hb_set_t       *set,
 		  hb_codepoint_t  first,
 		  hb_codepoint_t  last);
 
-void
+HB_EXTERN void
 hb_set_del (hb_set_t       *set,
 	    hb_codepoint_t  codepoint);
 
-void
+HB_EXTERN void
 hb_set_del_range (hb_set_t       *set,
 		  hb_codepoint_t  first,
 		  hb_codepoint_t  last);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_set_is_equal (const hb_set_t *set,
 		 const hb_set_t *other);
 
-void
+HB_EXTERN void
 hb_set_set (hb_set_t       *set,
 	    const hb_set_t *other);
 
-void
+HB_EXTERN void
 hb_set_union (hb_set_t       *set,
 	      const hb_set_t *other);
 
-void
+HB_EXTERN void
 hb_set_intersect (hb_set_t       *set,
 		  const hb_set_t *other);
 
-void
+HB_EXTERN void
 hb_set_subtract (hb_set_t       *set,
 		 const hb_set_t *other);
 
-void
+HB_EXTERN void
 hb_set_symmetric_difference (hb_set_t       *set,
 			     const hb_set_t *other);
 
-void
+HB_EXTERN void
 hb_set_invert (hb_set_t *set);
 
-unsigned int
+HB_EXTERN unsigned int
 hb_set_get_population (const hb_set_t *set);
 
 /* Returns -1 if set empty. */
-hb_codepoint_t
+HB_EXTERN hb_codepoint_t
 hb_set_get_min (const hb_set_t *set);
 
 /* Returns -1 if set empty. */
-hb_codepoint_t
+HB_EXTERN hb_codepoint_t
 hb_set_get_max (const hb_set_t *set);
 
 /* Pass -1 in to get started. */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_set_next (const hb_set_t *set,
 	     hb_codepoint_t *codepoint);
 
 /* Pass -1 for first and last to get started. */
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_set_next_range (const hb_set_t *set,
 		   hb_codepoint_t *first,
 		   hb_codepoint_t *last);

--- a/src/hb-shape-plan.h
+++ b/src/hb-shape-plan.h
@@ -38,49 +38,49 @@ HB_BEGIN_DECLS
 
 typedef struct hb_shape_plan_t hb_shape_plan_t;
 
-hb_shape_plan_t *
+HB_EXTERN hb_shape_plan_t *
 hb_shape_plan_create (hb_face_t                     *face,
 		      const hb_segment_properties_t *props,
 		      const hb_feature_t            *user_features,
 		      unsigned int                   num_user_features,
 		      const char * const            *shaper_list);
 
-hb_shape_plan_t *
+HB_EXTERN hb_shape_plan_t *
 hb_shape_plan_create_cached (hb_face_t                     *face,
 			     const hb_segment_properties_t *props,
 			     const hb_feature_t            *user_features,
 			     unsigned int                   num_user_features,
 			     const char * const            *shaper_list);
 
-hb_shape_plan_t *
+HB_EXTERN hb_shape_plan_t *
 hb_shape_plan_get_empty (void);
 
-hb_shape_plan_t *
+HB_EXTERN hb_shape_plan_t *
 hb_shape_plan_reference (hb_shape_plan_t *shape_plan);
 
-void
+HB_EXTERN void
 hb_shape_plan_destroy (hb_shape_plan_t *shape_plan);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_shape_plan_set_user_data (hb_shape_plan_t    *shape_plan,
 			     hb_user_data_key_t *key,
 			     void *              data,
 			     hb_destroy_func_t   destroy,
 			     hb_bool_t           replace);
 
-void *
+HB_EXTERN void *
 hb_shape_plan_get_user_data (hb_shape_plan_t    *shape_plan,
 			     hb_user_data_key_t *key);
 
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_shape_plan_execute (hb_shape_plan_t    *shape_plan,
 		       hb_font_t          *font,
 		       hb_buffer_t        *buffer,
 		       const hb_feature_t *features,
 		       unsigned int        num_features);
 
-const char *
+HB_EXTERN const char *
 hb_shape_plan_get_shaper (hb_shape_plan_t *shape_plan);
 
 

--- a/src/hb-shape.h
+++ b/src/hb-shape.h
@@ -47,29 +47,29 @@ typedef struct hb_feature_t {
   unsigned int  end;
 } hb_feature_t;
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_feature_from_string (const char *str, int len,
 			hb_feature_t *feature);
 
-void
+HB_EXTERN void
 hb_feature_to_string (hb_feature_t *feature,
 		      char *buf, unsigned int size);
 
 
-void
+HB_EXTERN void
 hb_shape (hb_font_t           *font,
 	  hb_buffer_t         *buffer,
 	  const hb_feature_t  *features,
 	  unsigned int         num_features);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_shape_full (hb_font_t          *font,
 	       hb_buffer_t        *buffer,
 	       const hb_feature_t *features,
 	       unsigned int        num_features,
 	       const char * const *shaper_list);
 
-const char **
+HB_EXTERN const char **
 hb_shape_list_shapers (void);
 
 

--- a/src/hb-unicode.h
+++ b/src/hb-unicode.h
@@ -174,23 +174,23 @@ typedef struct hb_unicode_funcs_t hb_unicode_funcs_t;
 /*
  * just give me the best implementation you've got there.
  */
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_unicode_funcs_get_default (void);
 
 
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_unicode_funcs_create (hb_unicode_funcs_t *parent);
 
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_unicode_funcs_get_empty (void);
 
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_unicode_funcs_reference (hb_unicode_funcs_t *ufuncs);
 
-void
+HB_EXTERN void
 hb_unicode_funcs_destroy (hb_unicode_funcs_t *ufuncs);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_unicode_funcs_set_user_data (hb_unicode_funcs_t *ufuncs,
 			        hb_user_data_key_t *key,
 			        void *              data,
@@ -198,18 +198,18 @@ hb_unicode_funcs_set_user_data (hb_unicode_funcs_t *ufuncs,
 				hb_bool_t           replace);
 
 
-void *
+HB_EXTERN void *
 hb_unicode_funcs_get_user_data (hb_unicode_funcs_t *ufuncs,
 			        hb_user_data_key_t *key);
 
 
-void
+HB_EXTERN void
 hb_unicode_funcs_make_immutable (hb_unicode_funcs_t *ufuncs);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_unicode_funcs_is_immutable (hb_unicode_funcs_t *ufuncs);
 
-hb_unicode_funcs_t *
+HB_EXTERN hb_unicode_funcs_t *
 hb_unicode_funcs_get_parent (hb_unicode_funcs_t *ufuncs);
 
 
@@ -285,7 +285,7 @@ typedef unsigned int			(*hb_unicode_decompose_compatibility_func_t)	(hb_unicode_
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_combining_class_func (hb_unicode_funcs_t *ufuncs,
 					   hb_unicode_combining_class_func_t func,
 					   void *user_data, hb_destroy_func_t destroy);
@@ -301,7 +301,7 @@ hb_unicode_funcs_set_combining_class_func (hb_unicode_funcs_t *ufuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_eastasian_width_func (hb_unicode_funcs_t *ufuncs,
 					   hb_unicode_eastasian_width_func_t func,
 					   void *user_data, hb_destroy_func_t destroy);
@@ -317,7 +317,7 @@ hb_unicode_funcs_set_eastasian_width_func (hb_unicode_funcs_t *ufuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_general_category_func (hb_unicode_funcs_t *ufuncs,
 					    hb_unicode_general_category_func_t func,
 					    void *user_data, hb_destroy_func_t destroy);
@@ -333,7 +333,7 @@ hb_unicode_funcs_set_general_category_func (hb_unicode_funcs_t *ufuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_mirroring_func (hb_unicode_funcs_t *ufuncs,
 				     hb_unicode_mirroring_func_t func,
 				     void *user_data, hb_destroy_func_t destroy);
@@ -349,7 +349,7 @@ hb_unicode_funcs_set_mirroring_func (hb_unicode_funcs_t *ufuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_script_func (hb_unicode_funcs_t *ufuncs,
 				  hb_unicode_script_func_t func,
 				  void *user_data, hb_destroy_func_t destroy);
@@ -365,7 +365,7 @@ hb_unicode_funcs_set_script_func (hb_unicode_funcs_t *ufuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_compose_func (hb_unicode_funcs_t *ufuncs,
 				   hb_unicode_compose_func_t func,
 				   void *user_data, hb_destroy_func_t destroy);
@@ -381,7 +381,7 @@ hb_unicode_funcs_set_compose_func (hb_unicode_funcs_t *ufuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_decompose_func (hb_unicode_funcs_t *ufuncs,
 				     hb_unicode_decompose_func_t func,
 				     void *user_data, hb_destroy_func_t destroy);
@@ -397,7 +397,7 @@ hb_unicode_funcs_set_decompose_func (hb_unicode_funcs_t *ufuncs,
  *
  * Since: 0.9.2
  **/
-void
+HB_EXTERN void
 hb_unicode_funcs_set_decompose_compatibility_func (hb_unicode_funcs_t *ufuncs,
 						   hb_unicode_decompose_compatibility_func_t func,
 						   void *user_data, hb_destroy_func_t destroy);
@@ -407,42 +407,42 @@ hb_unicode_funcs_set_decompose_compatibility_func (hb_unicode_funcs_t *ufuncs,
 /**
  * Since: 0.9.2
  **/
-hb_unicode_combining_class_t
+HB_EXTERN hb_unicode_combining_class_t
 hb_unicode_combining_class (hb_unicode_funcs_t *ufuncs,
 			    hb_codepoint_t unicode);
 
 /**
  * Since: 0.9.2
  **/
-unsigned int
+HB_EXTERN unsigned int
 hb_unicode_eastasian_width (hb_unicode_funcs_t *ufuncs,
 			    hb_codepoint_t unicode);
 
 /**
  * Since: 0.9.2
  **/
-hb_unicode_general_category_t
+HB_EXTERN hb_unicode_general_category_t
 hb_unicode_general_category (hb_unicode_funcs_t *ufuncs,
 			     hb_codepoint_t unicode);
 
 /**
  * Since: 0.9.2
  **/
-hb_codepoint_t
+HB_EXTERN hb_codepoint_t
 hb_unicode_mirroring (hb_unicode_funcs_t *ufuncs,
 		      hb_codepoint_t unicode);
 
 /**
  * Since: 0.9.2
  **/
-hb_script_t
+HB_EXTERN hb_script_t
 hb_unicode_script (hb_unicode_funcs_t *ufuncs,
 		   hb_codepoint_t unicode);
 
 /**
  * Since: 0.9.2
  **/
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_unicode_compose (hb_unicode_funcs_t *ufuncs,
 		    hb_codepoint_t      a,
 		    hb_codepoint_t      b,
@@ -451,7 +451,7 @@ hb_unicode_compose (hb_unicode_funcs_t *ufuncs,
 /**
  * Since: 0.9.2
  **/
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_unicode_decompose (hb_unicode_funcs_t *ufuncs,
 		      hb_codepoint_t      ab,
 		      hb_codepoint_t     *a,
@@ -460,7 +460,7 @@ hb_unicode_decompose (hb_unicode_funcs_t *ufuncs,
 /**
  * Since: 0.9.2
  **/
-unsigned int
+HB_EXTERN unsigned int
 hb_unicode_decompose_compatibility (hb_unicode_funcs_t *ufuncs,
 				    hb_codepoint_t      u,
 				    hb_codepoint_t     *decomposed);

--- a/src/hb-uniscribe.h
+++ b/src/hb-uniscribe.h
@@ -34,10 +34,10 @@
 HB_BEGIN_DECLS
 
 
-LOGFONTW *
+HB_EXTERN LOGFONTW *
 hb_uniscribe_font_get_logfontw (hb_font_t *font);
 
-HFONT
+HB_EXTERN HFONT
 hb_uniscribe_font_get_hfont (hb_font_t *font);
 
 

--- a/src/hb-version.h.in
+++ b/src/hb-version.h.in
@@ -47,15 +47,15 @@ HB_BEGIN_DECLS
 	 HB_VERSION_MAJOR*10000+HB_VERSION_MINOR*100+HB_VERSION_MICRO)
 
 
-void
+HB_EXTERN void
 hb_version (unsigned int *major,
 	    unsigned int *minor,
 	    unsigned int *micro);
 
-const char *
+HB_EXTERN const char *
 hb_version_string (void);
 
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_version_atleast (unsigned int major,
 		    unsigned int minor,
 		    unsigned int micro);

--- a/src/hb.h
+++ b/src/hb.h
@@ -28,6 +28,10 @@
 #define HB_H
 #define HB_H_IN
 
+#ifndef HB_EXTERN
+#define HB_EXTERN extern
+#endif
+
 #include "hb-blob.h"
 #include "hb-buffer.h"
 #include "hb-common.h"


### PR DESCRIPTION
Hi,

This is a follow-up PR from the discussions in PR #164 to use compiler directives to export symbols using compiler directives, which involves:

-Making sure config.h, if included, is included as the first thing in each source file under src/ (it is already so)
-Decorating the public symbols in the public headers with HB_EXTERN, which is extern by default.
-Add items in the autotools files to use visibility attributes to export symbols upon builds, by overriding HB_EXTERN.  This is similar to what is now done in GLib, GTK+, Clutter, etc.
-(In PR #164) add corresponding #defines for HB_EXTERN in the pre-configured config.h.win32.in to do the same for MSVC builds.

With blessings, thank you!