### PR TITLE
hb-private.hh needs to #include Windows.h under MSVC

### DIFF
--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -53,6 +53,10 @@
 #include <errno.h>
 #include <stdarg.h>
 
+#ifdef _MSC_VER
+#include <windows.h> /* ensure DEFINE_ENUM_FLAG_OPERATORS is defined */
+#endif
+
 
 /* Compile-time custom allocator support. */
 


### PR DESCRIPTION
This is needed to ensure DEFINE_ENUM_FLAG_OPERATORS works as expected. See https://bugzilla.mozilla.org/show_bug.cgi?id=1226175#c10.