### PR TITLE
Fix y_scale problems in hb-gr

### DIFF
--- a/src/hb-graphite2.cc
+++ b/src/hb-graphite2.cc
@@ -351,6 +351,7 @@ _hb_graphite2_shape (hb_shape_plan_t    *shape_plan,
   }
   buffer->len = glyph_count;
 
+  float yscale = font->y_scale / font->x_scale;
   /* Positioning. */
   if (!HB_DIRECTION_IS_BACKWARD(buffer->props.direction))
   {
@@ -359,9 +360,9 @@ _hb_graphite2_shape (hb_shape_plan_t    *shape_plan,
          is; pPos++, is = gr_slot_next_in_segment (is))
     {
       pPos->x_offset = gr_slot_origin_X (is) - curradvx;
-      pPos->y_offset = gr_slot_origin_Y (is) - curradvy;
+      pPos->y_offset = gr_slot_origin_Y (is) * yscale - curradvy;
       pPos->x_advance = gr_slot_advance_X (is, grface, grfont);
-      pPos->y_advance = gr_slot_advance_Y (is, grface, grfont);
+      pPos->y_advance = gr_slot_advance_Y (is, grface, grfont) * yscale;
       curradvx += pPos->x_advance;
       curradvy += pPos->y_advance;
     }
@@ -387,17 +388,17 @@ _hb_graphite2_shape (hb_shape_plan_t    *shape_plan,
         for (tis = is, tinfo = info; tis && tinfo->cluster == currclus; tis = gr_slot_prev_in_segment (tis), tinfo--)
         {
           clusx += gr_slot_advance_X (tis, grface, grfont);
-          clusy += gr_slot_advance_Y (tis, grface, grfont);
+          clusy += gr_slot_advance_Y (tis, grface, grfont) * yscale;
         }
         curradvx += clusx;
         curradvy += clusy;
       }
       pPos->x_advance = gr_slot_advance_X (is, grface, grfont);
-      pPos->y_advance = gr_slot_advance_Y (is, grface, grfont);
+      pPos->y_advance = gr_slot_advance_Y (is, grface, grfont) * yscale;
       curradvx -= pPos->x_advance;
       curradvy -= pPos->y_advance;
       pPos->x_offset = gr_slot_origin_X (is) - curradvx;
-      pPos->y_offset = gr_slot_origin_Y (is) - curradvy;
+      pPos->y_offset = gr_slot_origin_Y (is) * yscale - curradvy;
     }
     hb_buffer_reverse_clusters (buffer);
   }


### PR DESCRIPTION
In pango, the font->y_scale is set to be -font->x_scale. hb-gr is not honouring that, or any other difference between x and y scale. This patch changes that so that the output allows for difference in scale values.