### PR TITLE
hb-coretext.h: include CoreText.h and CoreGraphics.h

### DIFF
--- a/src/hb-coretext.h
+++ b/src/hb-coretext.h
@@ -30,12 +30,8 @@
 #include "hb.h"
 
 #include <TargetConditionals.h>
-#if TARGET_OS_IPHONE
-#  include <CoreText/CoreText.h>
-#  include <CoreGraphics/CoreGraphics.h>
-#else
-#  include <ApplicationServices/ApplicationServices.h>
-#endif
+#include <CoreText/CoreText.h>
+#include <CoreGraphics/CoreGraphics.h>
 
 HB_BEGIN_DECLS
 


### PR DESCRIPTION
Addresses #183.