### PR TITLE
AIX fixes

### DIFF
--- a/src/check-header-guards.sh
+++ b/src/check-header-guards.sh
@@ -9,13 +9,12 @@ stat=0
 test "x$HBHEADERS" = x && HBHEADERS=`cd "$srcdir"; find . -maxdepth 1 -name 'hb*.h'`
 test "x$HBSOURCES" = x && HBSOURCES=`cd "$srcdir"; find . -maxdepth 1 -name 'hb-*.cc' -or -name 'hb-*.hh'`
 
-
 for x in $HBHEADERS $HBSOURCES; do
 	test -f "$srcdir/$x" && x="$srcdir/$x"
-	echo "$x" | grep '[^h]$' -q && continue;
+	echo "$x" | grep -q '[^h]$' && continue;
 	xx=`echo "$x" | sed 's@.*/@@'`
 	tag=`echo "$xx" | tr 'a-z.-' 'A-Z_'`
-	lines=`grep "\<$tag\>" "$x" | wc -l | sed 's/[ 	]*//g'`
+	lines=`grep -w "$tag" "$x" | wc -l | sed 's/[ 	]*//g'`
 	if test "x$lines" != x3; then
 		echo "Ouch, header file $x does not have correct preprocessor guards"
 		stat=1

--- a/src/hb-font-private.hh
+++ b/src/hb-font-private.hh
@@ -82,7 +82,7 @@ struct hb_font_funcs_t {
       HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
     } f;
-    void (*array[]) (void);
+    void (*array[VAR]) (void);
   } get;
 };
 

--- a/src/hb-open-type-private.hh
+++ b/src/hb-open-type-private.hh
@@ -103,9 +103,6 @@ static inline Type& StructAfter(TObject &X)
   static const unsigned int static_size = (size); \
   static const unsigned int min_size = (size)
 
-/* Size signifying variable-sized array */
-#define VAR 1
-
 #define DEFINE_SIZE_UNION(size, _member) \
   DEFINE_INSTANCE_ASSERTION (this->u._member.static_size == (size)); \
   static const unsigned int min_size = (size)

--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -1005,5 +1005,7 @@ hb_options (void)
   return _hb_options.opts;
 }
 
+/* Size signifying variable-sized array */
+#define VAR 1
 
 #endif /* HB_PRIVATE_HH */


### PR DESCRIPTION
- use '-w' instead of '\<...\>' for check-header-guards
  grep manpage says these are the same

- move order of '-q' option to grep

- hb-font-private.hh - use [0] instead of [] for variable array
