### PR TITLE
Remove unused `retry:` label.

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -693,7 +693,6 @@ resize_and_retry:
     scratch += old_scratch_used;
     scratch_size -= old_scratch_used;
   }
-retry:
   {
     string_ref = CFStringCreateWithCharactersNoCopy (NULL,
 						     pchars, chars_len,


### PR DESCRIPTION
Fixes a -Wunused-label warning when building harfbuzz with clang -Wall.