### PR TITLE
Fix what looks like a copy-paste error in c79865f9

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -1157,7 +1157,7 @@ _hb_coretext_aat_shaper_face_data_create (hb_face_t *face)
   }
   hb_blob_destroy (mort_blob);
 
-  return hb_coretext_shaper_face_data_ensure (face) ? (hb_coretext_aat_shaper_face_data_t *) HB_SHAPER_DATA_SUCCEEDED : NULL;
+  return hb_coretext_aat_shaper_face_data_ensure (face) ? (hb_coretext_aat_shaper_face_data_t *) HB_SHAPER_DATA_SUCCEEDED : NULL;
 }
 
 void
@@ -1175,7 +1175,7 @@ struct hb_coretext_aat_shaper_font_data_t {};
 hb_coretext_aat_shaper_font_data_t *
 _hb_coretext_aat_shaper_font_data_create (hb_font_t *font)
 {
-  return hb_coretext_shaper_font_data_ensure (font) ? (hb_coretext_aat_shaper_font_data_t *) HB_SHAPER_DATA_SUCCEEDED : NULL;
+  return hb_coretext_aat_shaper_font_data_ensure (font) ? (hb_coretext_aat_shaper_font_data_t *) HB_SHAPER_DATA_SUCCEEDED : NULL;
 }
 
 void


### PR DESCRIPTION
Else, nothing uses the functions defined by
```
HB_SHAPER_DATA_ENSURE_DECLARE(coretext_aat, face)
HB_SHAPER_DATA_ENSURE_DECLARE(coretext_aat, font)
```