### PR TITLE
Remove unused HB_SHAPER_DATA_ENSURE_DECLARE lines.

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -1128,10 +1128,6 @@ fail:
  * AAT shaper
  */
 
-HB_SHAPER_DATA_ENSURE_DECLARE(coretext_aat, face)
-HB_SHAPER_DATA_ENSURE_DECLARE(coretext_aat, font)
-
-
 /*
  * shaper face data
  */


### PR DESCRIPTION
The coretext_aat shaper delegates to the regular coretext_..._ensure() functions, so coretext_aat_..._ensure() functions defined by these macros are unused. The compiler warns about them, which in turn can confuse people to think that the coretext_aat_..._ensure() functions weren't called by accident.