### PR TITLE
[docs] Fix gtk-doc waring

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -50,7 +50,7 @@
 #endif
 
 
-struct hb_blob_t {
+struct hb_blob {
   hb_object_header_t header;
   ASSERT_POD ();
 

--- a/src/hb-blob.h
+++ b/src/hb-blob.h
@@ -62,7 +62,7 @@ typedef enum {
   HB_MEMORY_MODE_READONLY_MAY_MAKE_WRITABLE
 } hb_memory_mode_t;
 
-typedef struct hb_blob_t hb_blob_t;
+typedef struct hb_blob hb_blob_t;
 
 HB_EXTERN hb_blob_t *
 hb_blob_create (const char        *data,

--- a/src/hb-buffer-private.hh
+++ b/src/hb-buffer-private.hh
@@ -71,7 +71,7 @@ HB_MARK_AS_FLAG_T (hb_buffer_scratch_flags_t);
  * hb_buffer_t
  */
 
-struct hb_buffer_t {
+struct hb_buffer {
   hb_object_header_t header;
   ASSERT_POD ();
 

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -139,7 +139,7 @@ hb_segment_properties_hash (const hb_segment_properties_t *p);
  * and output glyphs and their information after shaping.
  */
 
-typedef struct hb_buffer_t hb_buffer_t;
+typedef struct hb_buffer hb_buffer_t;
 
 HB_EXTERN hb_buffer_t *
 hb_buffer_create (void);

--- a/src/hb-face-private.hh
+++ b/src/hb-face-private.hh
@@ -40,7 +40,7 @@
  * hb_face_t
  */
 
-struct hb_face_t {
+struct hb_face {
   hb_object_header_t header;
   ASSERT_POD ();
 

--- a/src/hb-face.h
+++ b/src/hb-face.h
@@ -41,7 +41,7 @@ HB_BEGIN_DECLS
  * hb_face_t
  */
 
-typedef struct hb_face_t hb_face_t;
+typedef struct hb_face hb_face_t;
 
 HB_EXTERN hb_face_t *
 hb_face_create (hb_blob_t    *blob,

--- a/src/hb-font-private.hh
+++ b/src/hb-font-private.hh
@@ -57,7 +57,7 @@
   HB_FONT_FUNC_IMPLEMENT (glyph_from_name) \
   /* ^--- Add new callbacks here */
 
-struct hb_font_funcs_t {
+struct hb_font_funcs {
   hb_object_header_t header;
   ASSERT_POD ();
 
@@ -92,7 +92,7 @@ struct hb_font_funcs_t {
  * hb_font_t
  */
 
-struct hb_font_t {
+struct hb_font {
   hb_object_header_t header;
   ASSERT_POD ();
 

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -37,14 +37,14 @@
 HB_BEGIN_DECLS
 
 
-typedef struct hb_font_t hb_font_t;
+typedef struct hb_font hb_font_t;
 
 
 /*
  * hb_font_funcs_t
  */
 
-typedef struct hb_font_funcs_t hb_font_funcs_t;
+typedef struct hb_font_funcs hb_font_funcs_t;
 
 HB_EXTERN hb_font_funcs_t *
 hb_font_funcs_create (void);

--- a/src/hb-set-private.hh
+++ b/src/hb-set-private.hh
@@ -151,7 +151,7 @@ typedef hb_set_digest_combiner_t
 
 /* TODO Make this faster and memmory efficient. */
 
-struct hb_set_t
+struct hb_set
 {
   friend struct hb_frozen_set_t;
 

--- a/src/hb-set.h
+++ b/src/hb-set.h
@@ -41,7 +41,7 @@ HB_BEGIN_DECLS
  */
 #define HB_SET_VALUE_INVALID ((hb_codepoint_t) -1)
 
-typedef struct hb_set_t hb_set_t;
+typedef struct hb_set hb_set_t;
 
 
 HB_EXTERN hb_set_t *

--- a/src/hb-shape-plan-private.hh
+++ b/src/hb-shape-plan-private.hh
@@ -32,7 +32,7 @@
 #include "hb-shaper-private.hh"
 
 
-struct hb_shape_plan_t
+struct hb_shape_plan
 {
   hb_object_header_t header;
   ASSERT_POD ();

--- a/src/hb-shape-plan.h
+++ b/src/hb-shape-plan.h
@@ -36,7 +36,7 @@
 
 HB_BEGIN_DECLS
 
-typedef struct hb_shape_plan_t hb_shape_plan_t;
+typedef struct hb_shape_plan hb_shape_plan_t;
 
 HB_EXTERN hb_shape_plan_t *
 hb_shape_plan_create (hb_face_t                     *face,

--- a/src/hb-unicode-private.hh
+++ b/src/hb-unicode-private.hh
@@ -61,7 +61,7 @@ extern HB_INTERNAL const uint8_t _hb_modified_combining_class[256];
   HB_UNICODE_FUNC_IMPLEMENT (hb_script_t, script) \
   /* ^--- Add new simple callbacks here */
 
-struct hb_unicode_funcs_t {
+struct hb_unicode_funcs {
   hb_object_header_t header;
   ASSERT_POD ();
 

--- a/src/hb-unicode.h
+++ b/src/hb-unicode.h
@@ -168,7 +168,7 @@ typedef enum
  * hb_unicode_funcs_t
  */
 
-typedef struct hb_unicode_funcs_t hb_unicode_funcs_t;
+typedef struct hb_unicode_funcs hb_unicode_funcs_t;
 
 
 /*


### PR DESCRIPTION
I see a gazillion of warnings like:
Warning: multiple "IDs" for constraint linkend: hb-font-t.

It seems that typedefs like the one below confuses gtk-doc causing it to
generate several elements with the same id:
typedef struct hb_font_t hb_font_t;

GTK seems to prefix such hidden structs with underscore, not really a
fan of it but the warnings are too many to ignore.