### PR TITLE
Android: fix compile on arm64

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -25,7 +25,7 @@
  */
 
 /* http://www.oracle.com/technetwork/articles/servers-storage-dev/standardheaderfiles-453865.html */
-#ifndef _POSIX_C_SOURCE
+#if !defined(_POSIX_C_SOURCE) && !defined(ANDROID)
 #define _POSIX_C_SOURCE 199309L
 #endif
 


### PR DESCRIPTION
Android-21 seems to quite sensible on defining wrong _POSIX_C_SOURCE.
Check https://code.google.com/p/android/issues/detail?id=194631