### PR TITLE
Fix build with HB_DISABLE_DEPRECATED

### DIFF
--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -1538,6 +1538,8 @@ hb_font_get_ppem (hb_font_t *font,
 }
 
 
+#ifndef HB_DISABLE_DEPRECATED
+
 /*
  * Deprecated get_glyph_func():
  */
@@ -1660,3 +1662,5 @@ hb_font_funcs_set_glyph_func (hb_font_funcs_t *ffuncs,
 					  trampoline,
 					  trampoline_destroy);
 }
+
+#endif /* HB_DISABLE_DEPRECATED */


### PR DESCRIPTION
When HB_DISABLE_DEPRECATED is defined, no code from hb-deprecated.h
should be used, even from within HB itself.