### PR TITLE
Unbreak build on Windows CE

### DIFF
--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -169,6 +169,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #  if defined(_WIN32_WCE)
      /* Some things not defined on Windows CE. */
 #    define strdup _strdup
+#    define vsnprintf _vsnprintf
 #    define getenv(Name) NULL
 #    if _WIN32_WCE < 0x800
 #      define setlocale(Category, Locale) "C"


### PR DESCRIPTION
0475ef2f97e3035a2eea9a0f96031331e07e8e29 broke the build by using
vsnprintf(), which is not defined on Windows CE