### PR TITLE
Introduce hb-view-skia.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,7 +459,27 @@ if test "$os_win32" = no && ! $have_pthread; then
 	AC_SEARCH_LIBS(sched_yield,rt,AC_DEFINE(HAVE_SCHED_YIELD, 1, [Have sched_yield]))
 fi
 
+dnl ==========================================================================
+
+AC_ARG_WITH(skia,
+       [AS_HELP_STRING([--with-skia=@<:@yes/no/auto@:>@],
+                       [Use skia @<:@default=auto@:>@])],,
+       [with_skia=auto])
+have_skia=false
+if test "x$with_skia" = "xyes" -o "x$with_skia" = "xauto"; then
+       PKG_CHECK_MODULES(SKIA, skia >= 1.8.0, have_skia=true, :)
+fi
+if test "x$with_skia" = "xyes" -a "x$have_skia" != "xtrue"; then
+       AC_MSG_ERROR([skia support requested but not found])
+fi
+if $have_skia; then
+       AC_DEFINE(HAVE_SKIA, 1, [Have Skia graphics library])
+fi
+AM_CONDITIONAL(HAVE_SKIA, $have_skia)
+
+
 dnl ===========================================================================
+
 
 AC_CONFIG_FILES([
 Makefile

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -42,6 +42,19 @@ bin_PROGRAMS += hb-view
 endif # HAVE_CAIRO_FT
 endif # HAVE_FREETYPE
 
+if HAVE_SKIA
+AM_CPPFLAGS += \
+  $(SKIA_CFLAGS) \
+  $(NULL)
+
+hb_view_skia_SOURCES = $(HB_VIEW_SKIA_sources)
+hb_view_skia_LDADD = \
+	$(LDADD) \
+	$(SKIA_LIBS) \
+	$(NULL)
+bin_PROGRAMS += hb-view-skia
+endif # HAVE_SKIA
+
 hb_shape_SOURCES = $(HB_SHAPE_sources)
 bin_PROGRAMS += hb-shape
 

--- a/util/Makefile.sources
+++ b/util/Makefile.sources
@@ -16,6 +16,14 @@ HB_VIEW_sources = \
 	view-cairo.hh \
 	$(NULL)
 
+HB_VIEW_SKIA_sources = \
+	hb-view-skia.cc \
+	options.cc \
+	options.hh \
+	view-skia.cc \
+	view-skia.hh \
+	$(NULL)
+
 HB_SHAPE_sources = \
 	hb-shape.cc \
 	options.cc \

--- a/util/hb-view-skia.cc
+++ b/util/hb-view-skia.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2010  Behdad Esfahbod
+ * Copyright © 2011,2012  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Alexander Aprelev
+ */
+
+#include "main-font-text.hh"
+#include "shape-consumer.hh"
+#include "view-skia.hh"
+
+#define DEFAULT_FONT_SIZE 256
+#define SUBPIXEL_BITS 8
+
+int
+main (int argc, char **argv)
+{
+  main_font_text_t<shape_consumer_t<view_skia_t>, DEFAULT_FONT_SIZE, SUBPIXEL_BITS> driver;
+  return driver.main (argc, argv);
+}

--- a/util/view-skia.cc
+++ b/util/view-skia.cc
@@ -146,7 +146,6 @@ void view_skia_t::finish (const font_options_t *font_opts) {
   }
 
   SkCanvas* pageCanvas = pdfDocument->beginPage(w, h);
-  printf("w=%f, h=%f\n", w, h);
   pageCanvas->drawPaint(background_paint);
 
   double current_x = 0;

--- a/util/view-skia.cc
+++ b/util/view-skia.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2016  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Alexander Aprelev
+ */
+
+#include "view-skia.hh"
+
+#include <assert.h>
+
+const char *helper_skia_supported_formats[] =
+{
+  "pdf",
+  NULL
+};
+
+void view_skia_t::init (const font_options_t *_font_opts) {
+  font_opts = _font_opts;
+
+  lines = g_array_new (false, false, sizeof (SkTextBlob*));
+  scale_bits = -font_opts->subpixel_bits;
+
+  sk_sp<SkTypeface> fSkiaTypeface;
+  auto data = SkData::MakeFromFileName(font_opts->font_file);
+  assert(data);
+  if (!data) { return; }
+  fSkiaTypeface = SkTypeface::MakeFromStream(new SkMemoryStream(data), font_opts->face_index);
+  assert(fSkiaTypeface);
+  if (!fSkiaTypeface) { return; }
+
+  glyph_paint.setFlags(
+    SkPaint::kAntiAlias_Flag |
+    SkPaint::kSubpixelText_Flag);  // ... avoid waggly text when rotating.
+  glyph_paint.setColor(SK_ColorBLACK);
+  glyph_paint.setTextSize(font_opts->font_size_x);
+  SkAutoTUnref<SkFontMgr> fm(SkFontMgr::RefDefault());
+  glyph_paint.setTypeface(fSkiaTypeface);
+  glyph_paint.setTextEncoding(SkPaint::kGlyphID_TextEncoding);
+}
+
+void view_skia_t::consume_glyphs (hb_buffer_t  *buffer,
+                                  const char   *text,
+                                  unsigned int  text_len,
+                                  hb_bool_t     utf8_clusters) {
+  direction = hb_buffer_get_direction (buffer);
+
+  SkTextBlobBuilder text_blob_builder;
+  unsigned len = hb_buffer_get_length (buffer);
+  if (len == 0) {
+    return;
+  }
+  hb_glyph_info_t *info = hb_buffer_get_glyph_infos (buffer, NULL);
+  hb_glyph_position_t *pos = hb_buffer_get_glyph_positions (buffer, NULL);
+  auto run_buffer = text_blob_builder.allocRunPos(glyph_paint, len);
+
+  double x = 0;
+  double y = 0;
+  for (unsigned int i = 0; i < len; i++)
+  {
+    run_buffer.glyphs[i] = info[i].codepoint;
+
+    reinterpret_cast<SkPoint*>(run_buffer.pos)[i] = SkPoint::Make(
+      x + scalbn((double)pos[i].x_offset, scale_bits),
+      y - scalbn((double)pos[i].y_offset, scale_bits));
+    x += scalbn((double)pos[i].x_advance, scale_bits);
+    y += scalbn((double)pos[i].y_advance, scale_bits);
+  }
+  const SkTextBlob *text_blob = text_blob_builder.build();
+  g_array_append_val (lines, text_blob);
+}
+
+void view_skia_t::finish (const font_options_t *font_opts) {
+  auto data = SkData::MakeFromFileName(font_opts->font_file);
+  sk_sp<SkTypeface> fSkiaTypeface = fSkiaTypeface = SkTypeface::MakeFromStream(
+      new SkMemoryStream(data), font_opts->face_index);
+
+  SkDocument::PDFMetadata pdf_info;
+  SkTime::DateTime now;
+  SkTime::GetDateTime(&now);
+  pdf_info.fCreation.fEnabled = true;
+  pdf_info.fCreation.fDateTime = now;
+  pdf_info.fModified.fEnabled = true;
+  pdf_info.fModified.fDateTime = now;
+
+  SkFILEWStream *file_stream = nullptr;
+  SkDynamicMemoryWStream *memory_stream = nullptr;
+  SkWStream *output_stream = nullptr;
+  if (output_options.output_file != nullptr) {
+    file_stream = new SkFILEWStream(output_options.output_file);
+    output_stream = file_stream;
+  } else {
+    // when writing to stdout, write into memory stream first because
+    // there seems to be no way to point Skia stream to stdout.
+    memory_stream = new SkDynamicMemoryWStream();
+    output_stream = memory_stream;
+  }
+
+  sk_sp<SkDocument> pdfDocument = SkDocument::MakePDF(
+      output_stream, SK_ScalarDefaultRasterDPI,
+      pdf_info, nullptr, true);
+  assert(pdfDocument);
+
+  SkPaint background_paint;
+  background_paint.setColor(SK_ColorWHITE);
+
+  hb_font_t *font = font_opts->get_font();
+  hb_font_extents_t extents;
+  hb_font_get_extents_for_direction (font, direction, &extents);
+
+  double ascent = scalbn ((double) extents.ascender, scale_bits);
+  double descent = -scalbn ((double) extents.descender, scale_bits);
+  double font_height = scalbn ((double) extents.ascender - extents.descender + extents.line_gap, scale_bits);
+  double leading = font_height + view_options.line_space;
+
+  // Calculate width and height of one page that fits all consumed text.
+  double h = lines->len * leading + descent + view_options.line_space;
+  double w = 0;
+  for (unsigned int i = 0; i < lines->len; i++) {
+    SkTextBlob *text_blob = g_array_index (lines, SkTextBlob*, i);
+    SkRect bounds = text_blob->bounds();
+    double right = bounds.right();
+    w =  MAX (w, right);
+  }
+
+  SkCanvas* pageCanvas = pdfDocument->beginPage(w, h);
+  pageCanvas->drawPaint(background_paint);
+
+  double current_x = 0;
+  double current_y = leading;
+
+  for (unsigned int i = 0; i < lines->len; i++) {
+    SkTextBlob *text_blob = g_array_index (lines, SkTextBlob*, i);
+    pageCanvas->drawTextBlob(text_blob, current_x, current_y, glyph_paint);
+
+    current_y += leading;
+  }
+
+  pdfDocument->endPage();
+  pdfDocument->close();
+
+  if (memory_stream != nullptr) {
+    SkData* data = memory_stream->copyToData();
+    fwrite(data->data(), sizeof(char), data->size(), stdout);
+  }
+
+#if GLIB_CHECK_VERSION (2, 22, 0)
+  g_array_unref (lines);
+#else
+  g_array_free (lines, TRUE);
+#endif
+}

--- a/util/view-skia.cc
+++ b/util/view-skia.cc
@@ -159,7 +159,7 @@ void view_skia_t::finish (const font_options_t *font_opts) {
   pdfDocument->close();
 
   if (memory_stream != nullptr) {
-    SkData* data = memory_stream->copyToData();
+    SkAutoDataUnref data(memory_stream->copyToData());
     fwrite(data->data(), sizeof(char), data->size(), stdout);
   }
 

--- a/util/view-skia.hh
+++ b/util/view-skia.hh
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2011  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Alexander Aprelev
+ */
+
+#include "SkCanvas.h"
+#include "SkDocument.h"
+#include "SkFontMgr.h"
+#include "SkGradientShader.h"
+#include "SkPaint.h"
+#include "SkStream.h"
+#include "SkString.h"
+#include "SkTextBlob.h"
+#include "SkTypeface.h"
+
+#include "options.hh"
+
+#ifndef VIEW_SKIA_HH
+#define VIEW_SKIA_HH
+
+extern const char *helper_skia_supported_formats[];
+
+struct view_skia_t
+{
+  view_skia_t (option_parser_t *parser)
+               : output_options (parser, helper_skia_supported_formats),
+                 view_options (parser),
+                 direction (HB_DIRECTION_INVALID),
+                 scale_bits (0) {}
+
+  ~view_skia_t (void) {}
+
+  void init (const font_options_t *_font_opts);
+
+  void new_line (void) {}
+
+  void consume_text (hb_buffer_t  *buffer,
+                     const char   *text,
+                     unsigned int  text_len,
+                     hb_bool_t     utf8_clusters) {}
+
+  void shape_failed (hb_buffer_t  *buffer,
+                     const char   *text,
+                     unsigned int  text_len,
+                     hb_bool_t     utf8_clusters) {
+    fail (false, "all shapers failed");
+  }
+
+  void consume_glyphs (hb_buffer_t  *buffer,
+                       const char   *text,
+                       unsigned int  text_len,
+                       hb_bool_t     utf8_clusters);
+
+  void finish (const font_options_t *font_opts);
+
+ protected:
+  output_options_t output_options;
+  view_options_t view_options;
+  const font_options_t *font_opts;
+
+  hb_direction_t direction; // Remove this, make segment_properties accessible
+  GArray *lines;
+  int scale_bits;
+
+  SkPaint glyph_paint;
+};
+
+#endif


### PR DESCRIPTION
To follow-up on https://bugs.chromium.org/p/skia/issues/detail?id=4742#c14 this is working sketch of using Skia as backend for hb-view. Curious what you think, Behdad!

---

To build one needs to have Skia headers and libraries. Easiest way seem to be get Skia sources from https://skia.googlesource.com/skia, configure using cmake and build using ninja (cd ~/skia/skia/cmake && cmake . && ninja).
After that one can point to generated compile and link option files to auto-configure Harfbuzz with Skia:

```
SKIA_CFLAGS=`cat ~/skia/skia/cmake/skia_compile_arguments.txt | tr '\n' ' '` SKIA_LIBS=`cat ~/skia/skia/cmake/skia_link_arguments.txt | tr '\n' ' '` ./autogen.sh  --with-skia
```

To run:

```
cd util
make && ./hb-view-skia --output-format=pdf --font-file=${HOME}/fonts/DejaVuSans.ttf --font-size=64 < view-skia.cc > test.pdf && xdg-open test.pdf
```
