### PR TITLE
	[dwrite] Use stream font loader instead GDI interop

### DIFF
--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -664,11 +664,11 @@ _hb_directwrite_shape(hb_shape_plan_t    *shape_plan,
     (const DWRITE_TYPOGRAPHIC_FEATURES*) &singleFeatures;
   const uint32_t featureRangeLengths[] = { textLength };
 
-retry_getglyphs:
-  uint16_t* clusterMap = (uint16_t*) malloc (maxGlyphCount * sizeof (uint16_t));
-  uint16_t* glyphIndices = (uint16_t*) malloc (maxGlyphCount * sizeof (uint16_t));
+  uint16_t* clusterMap = (uint16_t*) malloc (textLength * sizeof (uint16_t));
   DWRITE_SHAPING_TEXT_PROPERTIES* textProperties = (DWRITE_SHAPING_TEXT_PROPERTIES*)
-    malloc (maxGlyphCount * sizeof (DWRITE_SHAPING_TEXT_PROPERTIES));
+    malloc (textLength * sizeof (DWRITE_SHAPING_TEXT_PROPERTIES));
+retry_getglyphs:
+  uint16_t* glyphIndices = (uint16_t*) malloc (maxGlyphCount * sizeof (uint16_t));
   DWRITE_SHAPING_GLYPH_PROPERTIES* glyphProperties = (DWRITE_SHAPING_GLYPH_PROPERTIES*)
     malloc (maxGlyphCount * sizeof (DWRITE_SHAPING_GLYPH_PROPERTIES));
 
@@ -679,9 +679,7 @@ retry_getglyphs:
 
   if (unlikely (hr == HRESULT_FROM_WIN32 (ERROR_INSUFFICIENT_BUFFER)))
   {
-    free (clusterMap);
     free (glyphIndices);
-    free (textProperties);
     free (glyphProperties);
 
     maxGlyphCount *= 2;
@@ -779,10 +777,10 @@ retry_getglyphs:
     // if a script justificationCharacter is not space, it can have GetJustifiedGlyphs
     if (justificationCharacter != 32)
     {
+      uint16_t* modifiedClusterMap = (uint16_t*) malloc (textLength * sizeof (uint16_t));
     retry_getjustifiedglyphs:
-      uint16_t* modifiedClusterMap = (uint16_t*) malloc (maxGlyphCount * sizeof(uint16_t));
-      uint16_t* modifiedGlyphIndices = (uint16_t*) malloc (maxGlyphCount * sizeof(uint16_t));
-      float* modifiedGlyphAdvances = (float*) malloc (maxGlyphCount * sizeof(float));
+      uint16_t* modifiedGlyphIndices = (uint16_t*) malloc (maxGlyphCount * sizeof (uint16_t));
+      float* modifiedGlyphAdvances = (float*) malloc (maxGlyphCount * sizeof (float));
       DWRITE_GLYPH_OFFSET* modifiedGlyphOffsets = (DWRITE_GLYPH_OFFSET*)
         malloc (maxGlyphCount * sizeof (DWRITE_GLYPH_OFFSET));
       uint32_t actualGlyphsCount;
@@ -795,7 +793,6 @@ retry_getglyphs:
       if (hr == HRESULT_FROM_WIN32 (ERROR_INSUFFICIENT_BUFFER))
       {
         maxGlyphCount = actualGlyphsCount;
-        free (modifiedClusterMap);
         free (modifiedGlyphIndices);
         free (modifiedGlyphAdvances);
         free (modifiedGlyphOffsets);

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -130,11 +130,12 @@ public:
 */
 
 struct hb_directwrite_shaper_face_data_t {
-  IDWriteFactory* dwriteFactory;
-  IDWriteFontFile* fontFile;
-  IDWriteFontFileLoader* fontFileLoader;
-  IDWriteFontFace* fontFace;
-  hb_blob_t* faceBlob;
+  IDWriteFactory *dwriteFactory;
+  IDWriteFontFile *fontFile;
+  IDWriteFontFileStream *fontFileStream;
+  IDWriteFontFileLoader *fontFileLoader;
+  IDWriteFontFace *fontFace;
+  hb_blob_t *faceBlob;
 };
 
 hb_directwrite_shaper_face_data_t *
@@ -195,6 +196,7 @@ _hb_directwrite_shaper_face_data_create(hb_face_t *face)
 
   data->dwriteFactory = dwriteFactory;
   data->fontFile = fontFile;
+  data->fontFileStream = fontFileStream;
   data->fontFileLoader = fontFileLoader;
   data->fontFace = fontFace;
   data->faceBlob = blob;
@@ -205,10 +207,23 @@ _hb_directwrite_shaper_face_data_create(hb_face_t *face)
 void
 _hb_directwrite_shaper_face_data_destroy(hb_directwrite_shaper_face_data_t *data)
 {
-  data->dwriteFactory->UnregisterFontFileLoader (data->fontFileLoader);
-  delete data->fontFileLoader;
-  hb_blob_destroy (data->faceBlob);
-  free (data);
+  if (data->fontFace)
+    data->fontFace->Release ();
+  if (data->fontFile)
+    data->fontFile->Release ();
+  if (data->dwriteFactory) {
+    if (data->fontFileLoader)
+      data->dwriteFactory->UnregisterFontFileLoader(data->fontFileLoader);
+    data->dwriteFactory->Release();
+  }
+  if (data->fontFileLoader)
+    delete data->fontFileLoader;
+  if (data->fontFileStream)
+    delete data->fontFileStream;
+  if (data->faceBlob)
+    hb_blob_destroy (data->faceBlob);
+  if (data)
+    free (data);
 }
 
 

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -134,6 +134,7 @@ struct hb_directwrite_shaper_face_data_t {
   IDWriteFontFile* fontFile;
   IDWriteFontFileLoader* fontFileLoader;
   IDWriteFontFace* fontFace;
+  hb_blob_t* faceBlob;
 };
 
 hb_directwrite_shaper_face_data_t *
@@ -153,7 +154,7 @@ _hb_directwrite_shaper_face_data_create(hb_face_t *face)
   );
 
   HRESULT hr;
-  hb_blob_t* blob = hb_face_reference_blob (face);
+  hb_blob_t *blob = hb_face_reference_blob (face);
   IDWriteFontFileStream *fontFileStream = new DWriteFontFileStream (
     (uint8_t*) hb_blob_get_data (blob, NULL), hb_blob_get_length (blob));
 
@@ -196,6 +197,7 @@ _hb_directwrite_shaper_face_data_create(hb_face_t *face)
   data->fontFile = fontFile;
   data->fontFileLoader = fontFileLoader;
   data->fontFace = fontFace;
+  data->faceBlob = blob;
 
   return data;
 }
@@ -205,6 +207,7 @@ _hb_directwrite_shaper_face_data_destroy(hb_directwrite_shaper_face_data_t *data
 {
   data->dwriteFactory->UnregisterFontFileLoader (data->fontFileLoader);
   delete data->fontFileLoader;
+  hb_blob_destroy (data->faceBlob);
   free (data);
 }
 

--- a/src/hb-directwrite.h
+++ b/src/hb-directwrite.h
@@ -31,4 +31,4 @@ HB_BEGIN_DECLS
 
 HB_END_DECLS
 
-#endif /* HB_UNISCRIBE_H */
+#endif /* HB_DIRECTWRITE_H */


### PR DESCRIPTION
This patch changes DirectWrite backend to use dwrite font file stream API instead falling back to Uniscribe suited solution, and also improves the backend to not create dwrite font object each shape time which have led to a significant performance boost on my tests. As the result of these changes the incorporated tricks to create HFONT objects are no longer needed on this backend so most of GDI backend shared codes are also removed.

In case no review would be given, I think this is ready to merge.