### PR TITLE
[dwrite] Provide an experimental API for justification

### DIFF
--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -209,8 +209,8 @@ _hb_directwrite_shaper_face_data_destroy(hb_directwrite_shaper_face_data_t *data
     data->fontFile->Release ();
   if (data->dwriteFactory) {
     if (data->fontFileLoader)
-      data->dwriteFactory->UnregisterFontFileLoader(data->fontFileLoader);
-    data->dwriteFactory->Release();
+      data->dwriteFactory->UnregisterFontFileLoader (data->fontFileLoader);
+    data->dwriteFactory->Release ();
   }
   if (data->fontFileLoader)
     delete data->fontFileLoader;
@@ -542,12 +542,13 @@ static inline uint32_t hb_uint32_swap (const uint32_t v)
  * shaper
  */
 
-hb_bool_t
-_hb_directwrite_shape(hb_shape_plan_t    *shape_plan,
+static hb_bool_t
+_hb_directwrite_shape_full(hb_shape_plan_t    *shape_plan,
   hb_font_t          *font,
   hb_buffer_t        *buffer,
   const hb_feature_t *features,
-  unsigned int        num_features)
+  unsigned int        num_features,
+  float               lineWidth)
 {
   hb_face_t *face = font->face;
   hb_directwrite_shaper_face_data_t *face_data = HB_SHAPER_DATA_GET (face);
@@ -728,9 +729,6 @@ retry_getglyphs:
     return false;
   }
 
-  // TODO: get lineWith from somewhere
-  float lineWidth = 0;
-
   IDWriteTextAnalyzer1* analyzer1;
   analyzer->QueryInterface (&analyzer1);
 
@@ -899,4 +897,38 @@ retry_getglyphs:
 
   /* Wow, done! */
   return true;
+}
+
+hb_bool_t
+_hb_directwrite_shape(hb_shape_plan_t    *shape_plan,
+  hb_font_t          *font,
+  hb_buffer_t        *buffer,
+  const hb_feature_t *features,
+  unsigned int        num_features)
+{
+  return _hb_directwrite_shape_full(shape_plan, font, buffer,
+    features, num_features, 0);
+}
+
+/*
+ * Public [experimental] API
+ */
+
+hb_bool_t
+hb_shape_dwrite_experimental_width(hb_font_t          *font,
+  hb_buffer_t        *buffer,
+  const hb_feature_t *features,
+  unsigned int        num_features,
+  float               width)
+{
+  static char *shapers = "directwrite";
+  hb_shape_plan_t *shape_plan = hb_shape_plan_create_cached (font->face,
+    &buffer->props, features, num_features, &shapers);
+  hb_bool_t res = _hb_directwrite_shape_full (shape_plan, font, buffer,
+    features, num_features, width);
+
+  if (res)
+    buffer->content_type = HB_BUFFER_CONTENT_TYPE_GLYPHS;
+
+  return res;
 }

--- a/src/hb-directwrite.h
+++ b/src/hb-directwrite.h
@@ -29,6 +29,10 @@
 
 HB_BEGIN_DECLS
 
+HB_EXTERN hb_bool_t
+hb_shape_dwrite_experimental_width(hb_font_t *font, hb_buffer_t *buffer,
+  const hb_feature_t *features, unsigned int num_features, float width);
+
 HB_END_DECLS
 
 #endif /* HB_DIRECTWRITE_H */


### PR DESCRIPTION
This is just created to start brain storming around the way we could have some initial justification API of at least directwrite backend on harfbuzz.

Ideally, from the start, we should think about how current harfbuzz can be developed in a way to provide a justification API that would be possible to be integrated with caching word shapers solutions where the "line" concept itself is less relevant...

Obviously harfbuzz API differs from paragraph like API such as DirectWrite and that's why integrating justification with the current state of harfbuzz and its clients usage needs some considerate and innovative thinking :)
