### PR TITLE
clang in MSVC mode doesn't like when we redefine __attribute__

### DIFF
--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -83,7 +83,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #define unlikely(expr) (expr)
 #endif
 
-#ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(__clang__)
 #undef __attribute__
 #define __attribute__(x)
 #endif


### PR DESCRIPTION
I suppose clang in GCC compatibility mode has no problem with this as it probably defines `__GNUC__`