### PR TITLE
clang from MSVC needs to include intrin.h before winnt.h

### DIFF
--- a/src/hb-atomic-private.hh
+++ b/src/hb-atomic-private.hh
@@ -32,6 +32,10 @@
 #ifndef HB_ATOMIC_PRIVATE_HH
 #define HB_ATOMIC_PRIVATE_HH
 
+#if defined(__clang__ ) && defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 #include "hb-private.hh"
 
 


### PR DESCRIPTION
I haven't found a better workaround. It we do this after `hb-private.hh` it doesn't work.