### PR TITLE
Don’t build UCDN support when building with GLib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,7 +288,7 @@ AM_CONDITIONAL(HAVE_ICU_BUILTIN, $have_icu && test "x$with_icu" = "xbuiltin")
 dnl ===========================================================================
 
 have_ucdn=true
-if $have_glib || $have_icu && test "x$with_icu" = "xbuiltin"; then
+if $have_glib || test \( $have_icu -a "x$with_icu" = "xbuiltin" \); then
 	have_ucdn=false
 fi
 if $have_ucdn; then


### PR DESCRIPTION
Regression from: b424b6c372dfe4c0ed75a49761eb34a416819446.