### PR TITLE
305% performance improvement with python bindings

### DIFF
--- a/src/hb-buffer-private.hh
+++ b/src/hb-buffer-private.hh
@@ -45,7 +45,7 @@
 #define HB_BUFFER_MAX_LEN_DEFAULT 0x3FFFFFFF /* Shaping more than a billion chars? Let us know! */
 #endif
 
-ASSERT_STATIC (sizeof (hb_glyph_info_t) == 20);
+ASSERT_STATIC (sizeof (hb_glyph_info_t) == 36);
 ASSERT_STATIC (sizeof (hb_glyph_info_t) == sizeof (hb_glyph_position_t));
 
 HB_MARK_AS_FLAG_T (hb_buffer_flags_t);

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -1380,6 +1380,31 @@ hb_buffer_get_glyph_positions (hb_buffer_t  *buffer,
 }
 
 /**
+ * hb_buffer_compact_glyphs:
+ * @buffer: an #hb_buffer_t.
+ *
+ * Since: ???
+ **/
+void
+hb_buffer_compact_glyphs (hb_buffer_t * buffer)
+{
+    assert (buffer->have_positions);
+    assert (buffer->content_type == HB_BUFFER_CONTENT_TYPE_GLYPHS);
+    
+    unsigned int count = buffer->len;
+    hb_glyph_info_t     *info = buffer->info;
+    hb_glyph_position_t *pos  = buffer->pos;
+    
+    for (unsigned int i = 0; i < count; i++)
+    {
+        pos[i].compact[0] = info[i].cluster;
+        pos[i].compact[1] = info[i].codepoint;
+        pos[i].compact[2] = pos [i].x_advance;
+        pos[i].compact[3] = pos [i].x_offset;
+    }
+}
+
+/**
  * hb_buffer_reverse:
  * @buffer: an #hb_buffer_t.
  *

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -65,7 +65,9 @@ typedef struct hb_glyph_info_t {
   hb_codepoint_t codepoint;
   hb_mask_t      mask;
   uint32_t       cluster;
-
+  
+  uint32_t       _filler[4]; // only to keep ASSERT equal size happy
+  
   /*< private >*/
   hb_var_int_t   var1;
   hb_var_int_t   var2;
@@ -92,7 +94,9 @@ typedef struct hb_glyph_position_t {
   hb_position_t  y_advance;
   hb_position_t  x_offset;
   hb_position_t  y_offset;
-
+  
+  uint32_t       compact[4];
+  
   /*< private >*/
   hb_var_int_t   var;
 } hb_glyph_position_t;
@@ -377,6 +381,8 @@ HB_EXTERN hb_glyph_position_t *
 hb_buffer_get_glyph_positions (hb_buffer_t  *buffer,
                                unsigned int *length);
 
+HB_EXTERN void
+hb_buffer_compact_glyphs (hb_buffer_t * buffer);
 
 HB_EXTERN void
 hb_buffer_normalize_glyphs (hb_buffer_t *buffer);


### PR DESCRIPTION
(Addresses #287)

There are probably many better ways of doing this than adding a field to `hb_glyph_position_t` but as a proof of concept, it is possible to achieve a roughly 300% increase in speed by having the glyph info/position lookups resolved in C rather than in Python through GObject.

````
def shape_new_buffer(extractor=lambda b: b):
    buf = hb.buffer_create ()
    hb.buffer_add_utf32 (buf, array.array('I', text.encode('utf-32')), 0, -1)
    hb.buffer_guess_segment_properties (buf)
    hb.shape (font, buf, [])
    return extractor(buf)

def unpack_hb_buffer1(HBB):
    return [(N.cluster, N.codepoint, P.x_advance, P.x_offset) for N, P in zip(hb.buffer_get_glyph_infos(HBB), hb.buffer_get_glyph_positions(HBB))]

def unpack_hb_buffer2(HBB):
    hb.buffer_compact_glyphs(HBB)
    return [P.compact for P in hb.buffer_get_glyph_positions(HBB)]

import timeit
t1 = timeit.timeit("shape_new_buffer(unpack_hb_buffer1)", number=1000, setup="from __main__ import shape_new_buffer, unpack_hb_buffer1")

t2 = timeit.timeit("shape_new_buffer(unpack_hb_buffer2)", number=1000, setup="from __main__ import shape_new_buffer, unpack_hb_buffer2")

print(t1)
print(t2)
print(t1/t2)

shaped_buffer = shape_new_buffer()

t3 = timeit.timeit("unpack_hb_buffer1(shaped_buffer)", number=1000, setup="from __main__ import shaped_buffer, unpack_hb_buffer1")

t4 = timeit.timeit("unpack_hb_buffer2(shaped_buffer)", number=1000, setup="from __main__ import shaped_buffer, unpack_hb_buffer2")

print(t3)
print(t4)
print(t3/t4)
````

````
0.5077813390016672
0.1881202860022313
2.6992375452567856 (overall stack performance improvement factor)
````
````
0.5054081650014268
0.16407813999830978
3.0802894584655407 (glyph extraction performance improvement factor)
````

This reduces the number of python attribute lookups required from 4 to 1 per glyph. Since sticking the values into the `hb_glyph_position_t` struct probably isn’t the best way to go, if there was a way to generate the array independently, testing shows it would probably achieve close to a 1000% percent performance improvement (since the bottleneck is still the one python attribute lookup).