### PR TITLE
Support Americanist Phonetic Notation

### DIFF
--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -892,11 +892,19 @@ hb_ot_tag_from_language (hb_language_t language)
   }
 
   /*
-   * The International Phonetic Alphabet is a variant tag in BCP-47,
-   * which can be applied to any language.
+   * "fonipa" is a variant tag in BCP-47, meaning the International Phonetic Alphabet.
+   * It can be applied to any language.
    */
   if (strstr (lang_str, "-fonipa")) {
     return HB_TAG('I','P','P','H');  /* Phonetic transcription—IPA conventions */
+  }
+
+  /*
+   * "fonnapa" is a variant tag in BCP-47, meaning the North American Phonetic Alphabet
+   * also known as Americanist Phonetic Notation.  It can be applied to any language.
+   */
+  if (strstr (lang_str, "-fonnapa")) {
+    return HB_TAG('A','P','P','H');  /* Phonetic transcription—Americanist conventions */
   }
 
   /* Find a language matching in the first component */
@@ -970,6 +978,8 @@ hb_ot_tag_to_language (hb_tag_t tag)
 
   /* struct LangTag has only room for 3-letter language tags. */
   switch (tag) {
+  case HB_TAG('A','P','P','H'):  /* Phonetic transcription—Americanist conventions */
+    return hb_language_from_string ("und-fonnapa", -1);
   case HB_TAG('I','P','P','H'):  /* Phonetic transcription—IPA conventions */
     return hb_language_from_string ("und-fonipa", -1);
   }

--- a/test/api/test-ot-tag.c
+++ b/test/api/test-ot-tag.c
@@ -232,6 +232,12 @@ test_ot_tag_language (void)
   test_tag_from_language ("IPPH", "zh-fonipa");
   test_tag_to_language ("IPPH", "und-fonipa");
 
+  /* North American Phonetic Alphabet (Americanist Phonetic Notation) */
+  test_tag_from_language ("APPH", "en-fonnapa");
+  test_tag_from_language ("APPH", "chr-fonnapa");
+  test_tag_from_language ("APPH", "und-fonnapa");
+  test_tag_to_language ("APPH", "und-fonnapa");
+
   /* Test that x-hbot overrides the base language */
   test_tag_from_language ("ABC", "fa-x-hbotabc-zxc");
   test_tag_from_language ("ABC", "fa-ir-x-hbotabc-zxc");


### PR DESCRIPTION
OpenType language system tag: `APPH`
https://www.microsoft.com/typography/otspec/languagetags.htm

IETF BCP47 variant tag: `fonnapa`
http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry