### PR TITLE
[ci] Add Windows CI support, provided by AppVeyor

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/behdad/harfbuzz.svg)](https://travis-ci.org/behdad/harfbuzz)
+[![Build Status](https://ci.appveyor.com/api/projects/status/4oaq58ns2h0m2soa?svg=true)](https://ci.appveyor.com/project/behdad/harfbuzz)
 [![Coverage Status](https://img.shields.io/coveralls/behdad/harfbuzz.svg)](https://coveralls.io/r/behdad/harfbuzz)
 [ABI Tracker](http://abi-laboratory.pro/tracker/timeline/harfbuzz/)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+platform: x64
+
+environment:
+  matrix:
+    - compiler: msvc
+      ARCH: amd64
+      CFG: release
+    - compiler: msvc
+      ARCH: x86
+      CFG: release
+    - compiler: msvc
+      ARCH: amd64
+      CFG: debug
+    - compiler: msvc
+      ARCH: x86
+      CFG: debug
+
+install:
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-x86_64-ragel"
+
+build_script:
+  - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%'
+  - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh; make distdir"
+  - cd harfbuzz-*\win32
+  - nmake /f Makefile.vc CFG=%CFG% DIRECTWRITE=1
+
+# disable automatic tests
+test: off

--- a/win32/generate-msvc.mak
+++ b/win32/generate-msvc.mak
@@ -23,4 +23,4 @@ $(HB_GOBJECT_ENUM_GENERATED_SOURCES): ..\src\hb-gobject-enums.h.tmpl ..\src\hb-g
 
 # Create the build directories
 $(CFG)\$(PLAT)\harfbuzz $(CFG)\$(PLAT)\harfbuzz-icu $(CFG)\$(PLAT)\harfbuzz-gobject $(CFG)\$(PLAT)\util:
-	@-mkdir $@
+	@-mkdir -p $@


### PR DESCRIPTION
The world is changed a lot since my last try for making this happen on #112, ragel added to msys2 ([by me](https://github.com/Alexpux/MINGW-packages/pull/645)), msys2 added on appveyor (I pushed this a bit also 😊) and since then both appveyor support for msys2 and msys2 itself perhaps are polished, @fanc999 added a nmake build project file for native win32 compiles, and I added DirectWrite backend to harfbuzz; and now it is the time for adding a deserving Windows CI to harfbuzz which compiles the project against MSVC compiler and gives us more confidence on harfbuzz development. And, [here](https://ci.appveyor.com/project/ebraminio/harfbuzz) is its result :)

Please take a look at it, thank you :)