### PR TITLE
[ci] Add msys2 build to CI and run its testsuite on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,14 +15,26 @@ environment:
       ARCH: x86
       CFG: debug
 
+    - compiler: msys2
+      MINGW_PREFIX: /c/msys2/mingw64/
+      MINGW_CHOST: x86_64-w64-mingw32
+      MSYS2_ARCH: x86_64
+    - compiler: msys2
+      MINGW_PREFIX: /c/msys2/mingw32/
+      MINGW_CHOST: i686-w64-mingw32
+      MSYS2_ARCH: i686
+
 install:
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-x86_64-ragel"
 
 build_script:
-  - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%'
-  - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh; make distdir"
-  - cd harfbuzz-*\win32
-  - nmake /f Makefile.vc CFG=%CFG% DIRECTWRITE=1
+  - 'if "%compiler%"=="msvc" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%'
+  - 'if "%compiler%"=="msvc" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh; make distdir"'
+  - 'if "%compiler%"=="msvc" cd harfbuzz-*\win32'
+  - 'if "%compiler%"=="msvc" nmake /f Makefile.vc CFG=%CFG% DIRECTWRITE=1'
+
+  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-$MSYS2_ARCH-{freetype,cairo,icu,gettext,gobject-introspection,gcc,gcc-libs,glib2,graphite2,pkg-config}"'
+  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh --with-uniscribe --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2 --build=$MINGW_CHOST --host=$MINGW_CHOST --prefix=$MINGW_PREFIX; make; make check"'
 
 # disable automatic tests
 test: off


### PR DESCRIPTION
This runs hb testsuite on msys2 but not against MSVC compiler and the original Windows SDK is not reachable (AFAIK) for this setup so no dwrite backend can be compiled here, but as uniscribe itself is a dwrite wrapper nowadays, one can use this infrastructure to setup automatic dwrite and harbuzz shapers comparator.