### PR TITLE
[coretext] Use intended coretext version check logic

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -152,7 +152,8 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
    * operating system versions. Except for the emoji font, where _not_
    * reconfiguring the cascade list causes CoreText crashes. For details, see
    * crbug.com/549610 */
-  if (&CTGetCoreTextVersion != NULL && CTGetCoreTextVersion() <= kCTVersionNumber10_9) {
+  // 0x00070000 stands for "kCTVersionNumber10_10", see CoreText.h
+  if (&CTGetCoreTextVersion != NULL && CTGetCoreTextVersion() < 0x00070000) {
     CFStringRef fontName = CTFontCopyPostScriptName (ct_font);
     bool isEmojiFont = CFStringCompare (fontName, CFSTR("AppleColorEmoji"), 0) == kCFCompareEqualTo;
     CFRelease (fontName);


### PR DESCRIPTION
Fix per [this](https://github.com/behdad/harfbuzz/commit/48677345281a93d8829dd37d0480a6062945416a#commitcomment-18945709) comment and the following.