### PR TITLE
Update detectenv-msvc.mak

### DIFF
--- a/win32/detectenv-msvc.mak
+++ b/win32/detectenv-msvc.mak
@@ -119,6 +119,9 @@ CFLAGS_ADD = /MDd /Od
 
 !if "$(PLAT)" == "x64"
 LDFLAGS_ARCH = /machine:x64
+!elseif "$(PLAT)" == "arm"
+LDFLAGS_ARCH = /machine:arm
+CFLAGS_ADD = $(CFLAGS_ADD) /DWINAPI_FAMILY=3
 !else
 LDFLAGS_ARCH = /machine:x86
 !endif


### PR DESCRIPTION
Windows x86 ARM capability

Can now build with Microsoft Visual Studio 2015 ARM x86 cross compiler using:
nmake /f Makefile.vc CFG=release PLAT=arm



However there is a problem excluding Uniscribe which I am hacking around with the following now:
config.h.win32: //#define HAVE_UNISCRIBE 1

src\Makefile.sources:
#HB_UNISCRIBE_sources = hb-uniscribe.cc
#HB_UNISCRIBE_headers = hb-uniscribe.h