### PR TITLE
Allow building with graphite2 without pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -307,6 +307,16 @@ GRAPHITE2_DEPS="graphite2"
 AC_SUBST(GRAPHITE2_DEPS)
 if test "x$with_graphite2" = "xyes" -o "x$with_graphite2" = "xauto"; then
 	PKG_CHECK_MODULES(GRAPHITE2, $GRAPHITE2_DEPS, have_graphite2=true, :)
+	if test "x$have_graphite2" != "xtrue"; then
+                # If pkg-config is not available, graphite2 can still be there
+		ac_save_CFLAGS="$CFLAGS"
+		ac_save_CPPFLAGS="$CPPFLAGS"
+		CFLAGS="$CFLAGS $GRAPHITE2_CFLAGS"
+		CPPFLAGS="$CPPFLAGS $GRAPHITE2_CFLAGS"
+		AC_CHECK_HEADER(graphite2/Segment.h, have_graphite2=true, :)
+		CPPFLAGS="$ac_save_CPPFLAGS"
+		CFLAGS="$ac_save_CFLAGS"
+	fi
 fi
 if test "x$with_graphite2" = "xyes" -a "x$have_graphite2" != "xtrue"; then
 	AC_MSG_ERROR([graphite2 support requested but libgraphite2 not found])


### PR DESCRIPTION
configure uses PKG_CHECK_MODULES to find graphite2. When pkg-config is not available (e.g., as when building statically within LibreOffice tree on OS X), PKG_CHECK_MODULES fails even though GRAPHITE2_CFLAGS and GRAPHITE2_LIBS are already defined by user. This patch makes configure use GRAPHITE2_CFLAGS to check for graphite2 usability when it is requested, even if PKG_CHECK_MODULES fails.