### PR TITLE
Make Uniscribe optional on nmake win32 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
   - 'if "%compiler%"=="msvc" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%'
   - 'if "%compiler%"=="msvc" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh; make distdir"'
   - 'if "%compiler%"=="msvc" cd harfbuzz-*\win32'
-  - 'if "%compiler%"=="msvc" nmake /f Makefile.vc CFG=%CFG% DIRECTWRITE=1'
+  - 'if "%compiler%"=="msvc" nmake /f Makefile.vc CFG=%CFG% UNISCRIBE=1 DIRECTWRITE=1'
 
   - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-$MSYS2_ARCH-{freetype,cairo,icu,gettext,gobject-introspection,gcc,gcc-libs,glib2,graphite2,pkg-config}"'
   - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh --with-uniscribe --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2 --build=$MINGW_CHOST --host=$MINGW_CHOST --prefix=$MINGW_PREFIX; make; make check"'

--- a/win32/README.txt
+++ b/win32/README.txt
@@ -7,11 +7,10 @@ Makefiles.
 The following are instructions for performing such a build, as there is a
 number of build configurations supported for the build.  Note that for all
 build configurations, the OpenType and Simple TrueType layout (fallback)
-backends are enabled, as well as the Uniscribe platform shaper, and this
-is the base configuration that is built if no options (see below) are
-specified.  A 'clean' target is provided-it is recommended that one cleans
-the build and redo the build if any configuration option changed.  An
-'install' target is also provided to copy the built items in their appropriate
+backends are enabled, and this is the base configuration that is built if no
+options (see below) are specified.  A 'clean' target is provided-it is recommended
+that one cleans the build and redo the build if any configuration option changed.
+An 'install' target is also provided to copy the built items in their appropriate
 locations under $(PREFIX), which is described below.
 
 Invoke the build by issuing the command:
@@ -68,7 +67,9 @@ ICU: Enables the build HarfBuzz-ICU, which is now the recommended layout engine
      for ICU (International Components for Unicode), which deprecated ICU LE.
      Requires the ICU libraries.
 
-DIRECTWRITE: Enable (experimental) DirectWrite platform shaper support,
+UNISCRIBE: Enable Uniscribe platform shaper support.
+
+DIRECTWRITE: Enable DirectWrite platform shaper support,
              requires a rather recent Windows SDK, and at least Windows Vista/
              Server 2008 with SP2 and platform update.
 

--- a/win32/config-msvc.mak
+++ b/win32/config-msvc.mak
@@ -20,6 +20,9 @@ CAIRO_LIB = cairo.lib
 # Graphite2 is needed for building SIL Graphite2 support
 GRAPHITE2_LIB = graphite2.lib
 
+# Uniscribe is needed for Uniscribe shaping support
+UNISCRIBE_LIB = usp10.lib gdi32.lib rpcrt4.lib user32.lib
+
 # Directwrite is needed for DirectWrite shaping support
 DIRECTWRITE_LIB = dwrite.lib
 
@@ -31,17 +34,15 @@ HB_UCDN_CFLAGS = /I..\src\hb-ucdn
 HB_SOURCES =	\
 	$(HB_BASE_sources)		\
 	$(HB_FALLBACK_sources)	\
-	$(HB_OT_sources)		\
-	$(HB_UNISCRIBE_sources)	\
+	$(HB_OT_sources)
 
 HB_HEADERS =	\
 	$(HB_BASE_headers)		\
 	$(HB_NODIST_headers)	\
-	$(HB_OT_headers)		\
-	$(HB_UNISCRIBE_headers)
+	$(HB_OT_headers)
 
 # Minimal set of (system) libraries needed for the HarfBuzz DLL
-HB_DEP_LIBS = usp10.lib gdi32.lib rpcrt4.lib user32.lib
+HB_DEP_LIBS =
 
 # We build the HarfBuzz DLL/LIB at least
 HB_LIBS = $(CFG)\$(PLAT)\harfbuzz.lib
@@ -186,6 +187,13 @@ HB_CFLAGS =	\
 	/D_CRT_NONSTDC_NO_WARNINGS
 
 HB_SOURCES = $(HB_SOURCES) $(LIBHB_UCDN_sources) $(HB_UCDN_sources)
+!endif
+
+!if "$(UNISCRIBE)" == "1"
+HB_CFLAGS = $(HB_CFLAGS) /DHAVE_UNISCRIBE
+HB_SOURCES = $(HB_SOURCES) $(HB_UNISCRIBE_sources)
+HB_HEADERS = $(HB_HEADERS) $(HB_UNISCRIBE_headers)
+HB_DEP_LIBS = $(HB_DEP_LIBS) $(UNISCRIBE_LIB)
 !endif
 
 !if "$(DIRECTWRITE)" == "1"

--- a/win32/config.h.win32.in
+++ b/win32/config.h.win32.in
@@ -115,7 +115,7 @@
 #define HAVE_UCDN 1
 
 /* Have Uniscribe library */
-#define HAVE_UNISCRIBE 1
+/* #undef HAVE_UNISCRIBE */
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #ifndef _MSC_VER

--- a/win32/info-msvc.mak
+++ b/win32/info-msvc.mak
@@ -1,6 +1,6 @@
 # NMake Makefile portion for displaying config info
 
-INC_FEATURES = Uniscribe Fallback OT
+INC_FEATURES = Fallback OT
 BUILT_TOOLS =
 BUILT_LIBRARIES = HarfBuzz
 
@@ -21,6 +21,10 @@ INC_FEATURES = $(INC_FEATURES) FreeType
 
 !if "$(GRAPHITE2)" == "1"
 INC_FEATURES = $(INC_FEATURES) Graphite2
+!endif
+
+!if "$(UNISCRIBE)" == "1"
+INC_FEATURES = $(INC_FEATURES) Uniscribe
 !endif
 
 !if "$(DIRECTWRITE)" == "1"
@@ -77,9 +81,12 @@ help:
 	@echo.
 	@echo OPTION: Optional, may be any of the following, use OPTION=1 to enable;
 	@echo multiple OPTION's may be used.  If no OPTION is specified, a default
-	@echo HarfBuzz DLL is built with OpenType, fallback and Uniscribe support
+	@echo HarfBuzz DLL is built with OpenType and fallback support
 	@echo with a bundled Unicode implementation (UCDN).
 	@echo ======
+	@echo UNISCRIBE:
+	@echo Enable Uniscribe support.
+	@echo.
 	@echo DIRECTWRITE:
 	@echo Enable DirectWrite support, requires a recent enough Windows SDK.
 	@echo.


### PR DESCRIPTION
Most of harfbuzz clients don't need uniscribe and directwrite support at all
as harfbuzz is a replacement for Uniscribe so Chromium and Firefox are using
harfbuzz without this on Windows.

This removal helps win32 nmake users which even don't use the backend to have
harfbuzz on a reduced binary size and libs count.