### PR TITLE
[ci] Enable hb-freetype on Windows build tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,19 @@ environment:
   matrix:
     - compiler: msvc
       ARCH: amd64
+      VCPKG_ARCH: x64-windows
       CFG: release
     - compiler: msvc
       ARCH: x86
+      VCPKG_ARCH: x86-windows
       CFG: release
     - compiler: msvc
       ARCH: amd64
+      VCPKG_ARCH: x64-windows
       CFG: debug
     - compiler: msvc
       ARCH: x86
+      VCPKG_ARCH: x86-windows
       CFG: debug
 
     - compiler: msys2
@@ -27,11 +31,18 @@ environment:
 install:
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-x86_64-ragel"
 
-build_script:
   - 'if "%compiler%"=="msvc" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%'
+  - 'if "%compiler%"=="msvc" git clone https://github.com/Microsoft/vcpkg'
+  - 'if "%compiler%"=="msvc" cd vcpkg'
+  - 'if "%compiler%"=="msvc" powershell -exec bypass scripts\bootstrap.ps1'
+  - 'if "%compiler%"=="msvc" vcpkg install freetype:%VCPKG_ARCH%'
+  - 'if "%compiler%"=="msvc" copy installed\%VCPKG_ARCH%\debug\lib\freetyped.lib installed\%VCPKG_ARCH%\lib"
+  - 'if "%compiler%"=="msvc" cd ..'
+
+build_script:
   - 'if "%compiler%"=="msvc" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh; make distdir"'
   - 'if "%compiler%"=="msvc" cd harfbuzz-*\win32'
-  - 'if "%compiler%"=="msvc" nmake /f Makefile.vc CFG=%CFG% UNISCRIBE=1 DIRECTWRITE=1'
+  - 'if "%compiler%"=="msvc" nmake /f Makefile.vc CFG=%CFG% UNISCRIBE=1 DIRECTWRITE=1 FREETYPE=1 FREETYPE_DIR=..\..\vcpkg\installed\%VCPKG_ARCH%\include ADDITIONAL_LIB_DIR=..\..\vcpkg\installed\%VCPKG_ARCH%\lib'
 
   - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-$MSYS2_ARCH-{freetype,cairo,icu,gettext,gobject-introspection,gcc,gcc-libs,glib2,graphite2,pkg-config}"'
   - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh --with-uniscribe --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2 --build=$MINGW_CHOST --host=$MINGW_CHOST --prefix=$MINGW_PREFIX; make; make check"'

--- a/win32/config-msvc.mak
+++ b/win32/config-msvc.mak
@@ -12,7 +12,11 @@ HB_GLIB_LIBS = glib-2.0.lib
 HB_GOBJECT_DEP_LIBS = gobject-2.0.lib $(HB_GLIB_LIBS)
 
 # Freetype is needed for building FreeType support and hb-view
+!if "$(CFG)" == "debug"
+FREETYPE_LIB = freetyped.lib
+!else
 FREETYPE_LIB = freetype.lib
+!endif
 
 # Cairo is needed for building hb-view
 CAIRO_LIB = cairo.lib
@@ -125,6 +129,9 @@ HB_DEFINES = $(HB_DEFINES) /DHAVE_CAIRO=1
 
 # Enable freetype if desired
 !if "$(FREETYPE)" == "1"
+!if "$(FREETYPE_DIR)" != ""
+HB_CFLAGS = $(HB_CFLAGS) /I$(FREETYPE_DIR)
+!endif
 HB_DEFINES = $(HB_DEFINES) /DHAVE_FREETYPE=1
 HB_SOURCES = $(HB_SOURCES) $(HB_FT_sources)
 HB_HEADERS = $(HB_HEADERS) $(HB_FT_headers)

--- a/win32/detectenv-msvc.mak
+++ b/win32/detectenv-msvc.mak
@@ -130,6 +130,9 @@ LDFLAGS_ARCH = /machine:x86
 CFLAGS = $(CFLAGS_ADD) /W3 /Zi /I.. /I..\src /I. /I$(PREFIX)\include
 
 LDFLAGS_BASE = $(LDFLAGS_ARCH) /libpath:$(PREFIX)\lib /DEBUG
+!if "$(ADDITIONAL_LIB_DIR)" != ""
+LDFLAGS_BASE = $(LDFLAGS_ARCH) /libpath:$(ADDITIONAL_LIB_DIR)
+!endif
 
 !if "$(CFG)" == "debug"
 LDFLAGS = $(LDFLAGS_BASE)


### PR DESCRIPTION
This merges back @vlj's local patches of vcpkg for enabling [hb-freetype](https://github.com/Microsoft/vcpkg/pull/144) there. Lets apply them locally so they would be unnecessary when the next version of harfbuzz released.