### PR TITLE
Khmer ZWNJ patch

### DIFF
--- a/src/hb-ot-layout-gsubgpos-private.hh
+++ b/src/hb-ot-layout-gsubgpos-private.hh
@@ -345,8 +345,8 @@ struct hb_apply_context_t :
       match_glyph_data = NULL,
       matcher.set_match_func (NULL, NULL);
       matcher.set_lookup_props (c->lookup_props);
-      /* Ignore ZWNJ if we are matching GSUB context, or matching GPOS. */
-      matcher.set_ignore_zwnj (context_match || c->table_index == 1);
+      /* Ignore ZWNJ if we are matching GSUB context, or matching GPOS, and if not asked not to. */
+      matcher.set_ignore_zwnj (!c->manual_zwnj && (context_match || c->table_index == 1));
       /* Ignore ZWJ if we are matching GSUB context, or matching GPOS, or if asked to. */
       matcher.set_ignore_zwj (context_match || c->table_index == 1 || c->auto_zwj);
       matcher.set_mask (context_match ? -1 : c->lookup_mask);
@@ -463,6 +463,7 @@ struct hb_apply_context_t :
   hb_buffer_t *buffer;
   hb_direction_t direction;
   hb_mask_t lookup_mask;
+  bool manual_zwnj;
   bool auto_zwj;
   recurse_func_t recurse_func;
   unsigned int nesting_level_left;
@@ -482,6 +483,7 @@ struct hb_apply_context_t :
 			font (font_), face (font->face), buffer (buffer_),
 			direction (buffer_->props.direction),
 			lookup_mask (1),
+			manual_zwnj (false),
 			auto_zwj (true),
 			recurse_func (NULL),
 			nesting_level_left (HB_MAX_NESTING_LEVEL),
@@ -495,6 +497,7 @@ struct hb_apply_context_t :
 			debug_depth (0) {}
 
   inline void set_lookup_mask (hb_mask_t mask) { lookup_mask = mask; }
+  inline void set_manual_zwnj (bool manual_zwnj_) { manual_zwnj = manual_zwnj_; }
   inline void set_auto_zwj (bool auto_zwj_) { auto_zwj = auto_zwj_; }
   inline void set_recurse_func (recurse_func_t func) { recurse_func = func; }
   inline void set_lookup_index (unsigned int lookup_index_) { lookup_index = lookup_index_; }

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1194,6 +1194,7 @@ inline void hb_ot_map_t::apply (const Proxy &proxy,
       if (!buffer->message (font, "start lookup %d", lookup_index)) continue;
       c.set_lookup_index (lookup_index);
       c.set_lookup_mask (lookups[table_index][i].mask);
+      c.set_manual_zwnj (lookups[table_index][i].manual_zwnj);
       c.set_auto_zwj (lookups[table_index][i].auto_zwj);
       apply_string<Proxy> (&c,
 			   proxy.table.get_lookup (lookup_index),

--- a/src/hb-ot-map-private.hh
+++ b/src/hb-ot-map-private.hh
@@ -50,6 +50,7 @@ struct hb_ot_map_t
     hb_mask_t mask;
     hb_mask_t _1_mask; /* mask for value=1, for quick access */
     unsigned int needs_fallback : 1;
+    unsigned int manual_zwnj : 1;
     unsigned int auto_zwj : 1;
 
     static int cmp (const feature_map_t *a, const feature_map_t *b)
@@ -58,6 +59,7 @@ struct hb_ot_map_t
 
   struct lookup_map_t {
     unsigned short index;
+    unsigned short manual_zwnj : 1;
     unsigned short auto_zwj : 1;
     hb_mask_t mask;
 
@@ -150,8 +152,9 @@ enum hb_ot_map_feature_flags_t {
   F_NONE		= 0x0000u,
   F_GLOBAL		= 0x0001u, /* Feature applies to all characters; results in no mask allocated for it. */
   F_HAS_FALLBACK	= 0x0002u, /* Has fallback implementation, so include mask bit even if feature not found. */
-  F_MANUAL_ZWJ		= 0x0004u, /* Don't skip over ZWJ when matching. */
-  F_GLOBAL_SEARCH	= 0x0008u  /* If feature not found in LangSys, look for it in global feature list and pick one. */
+  F_MANUAL_ZWNJ		= 0x0004u, /* Don't skip over ZWNJ when matching. */
+  F_MANUAL_ZWJ		= 0x0008u, /* Don't skip over ZWJ when matching. */
+  F_GLOBAL_SEARCH	= 0x0010u  /* If feature not found in LangSys, look for it in global feature list and pick one. */
 };
 HB_MARK_AS_FLAG_T (hb_ot_map_feature_flags_t);
 /* Macro version for where const is desired. */
@@ -196,6 +199,7 @@ struct hb_ot_map_builder_t
 				unsigned int  feature_index,
 				unsigned int  variations_index,
 				hb_mask_t     mask,
+				bool          manual_zwnj,
 				bool          auto_zwj);
 
   struct feature_info_t {

--- a/src/hb-ot-map.cc
+++ b/src/hb-ot-map.cc
@@ -85,6 +85,7 @@ hb_ot_map_builder_t::add_lookups (hb_ot_map_t  &m,
 				  unsigned int  feature_index,
 				  unsigned int  variations_index,
 				  hb_mask_t     mask,
+				  bool          manual_zwnj,
 				  bool          auto_zwj)
 {
   unsigned int lookup_indices[32];
@@ -112,6 +113,7 @@ hb_ot_map_builder_t::add_lookups (hb_ot_map_t  &m,
         return;
       lookup->mask = mask;
       lookup->index = lookup_indices[i];
+      lookup->manual_zwnj = manual_zwnj;
       lookup->auto_zwj = auto_zwj;
     }
 
@@ -243,6 +245,7 @@ hb_ot_map_builder_t::compile (hb_ot_map_t  &m,
     map->index[1] = feature_index[1];
     map->stage[0] = info->stage[0];
     map->stage[1] = info->stage[1];
+    map->manual_zwnj = (info->flags & F_MANUAL_ZWNJ) != 0;
     map->auto_zwj = !(info->flags & F_MANUAL_ZWJ);
     if ((info->flags & F_GLOBAL) && info->max_value == 1) {
       /* Uses the global bit */
@@ -285,6 +288,7 @@ hb_ot_map_builder_t::compile (hb_ot_map_t  &m,
 		     required_feature_index[table_index],
 		     variations_index,
 		     1 /* mask */,
+		     false /* manual_zwnj */,
 		     true /* auto_zwj */);
 
       for (unsigned i = 0; i < m.features.len; i++)
@@ -293,6 +297,7 @@ hb_ot_map_builder_t::compile (hb_ot_map_t  &m,
 		       m.features[i].index[table_index],
 		       variations_index,
 		       m.features[i].mask,
+		       m.features[i].manual_zwnj,
 		       m.features[i].auto_zwj);
 
       /* Sort lookups and merge duplicates */
@@ -307,6 +312,7 @@ hb_ot_map_builder_t::compile (hb_ot_map_t  &m,
 	  else
 	  {
 	    m.lookups[table_index][j].mask |= m.lookups[table_index][i].mask;
+	    m.lookups[table_index][j].manual_zwnj &= m.lookups[table_index][i].manual_zwnj;
 	    m.lookups[table_index][j].auto_zwj &= m.lookups[table_index][i].auto_zwj;
 	  }
 	m.lookups[table_index].shrink (j + 1);


### PR DESCRIPTION
This branch improve combination of consonant shifter and ZWNJ for Khmer in two ways:
- Enable blwf for the consonant shifter after ZWNJ: for KhmerOS (Danh Hong), KhmerUI (Microsoft)
- Do not ignore ZWNJ  for substitution (abvs in this case) lookups: for Mondulkiri (SIL)
