### PR TITLE
[coretext] Add CTFontRef constructor

### DIFF
--- a/src/hb-coretext.h
+++ b/src/hb-coretext.h
@@ -45,6 +45,9 @@ HB_BEGIN_DECLS
 
 
 HB_EXTERN hb_face_t *
+hb_coretext_face_create_from_ct_font (CTFontRef ct_font);
+
+HB_EXTERN hb_face_t *
 hb_coretext_face_create (CGFontRef cg_font);
 
 


### PR DESCRIPTION
An attempt to fix #291 and #361, currently `hb_coretext_face_create`, `hb_coretext_face_create_from_ctfont` are broken, however the easy path works fine and with very low amount of memory leak.

![image](https://cloud.githubusercontent.com/assets/833473/20646728/57a3cc6e-b496-11e6-8b59-21b6de3db5b0.png)
(compare the second row to #291 screenshot with ~14mb leak)