### PR TITLE
ICU_BUILTIN option for NMake build

### DIFF
--- a/win32/README.txt
+++ b/win32/README.txt
@@ -47,7 +47,7 @@ GOBJECT: Enable building the HarfBuzz-GObject DLL, and thus implies GLib
 INTROSPECTION: Enable build of introspection files, for making HarfBuzz
                bindings for other programming languages available, such as
                Python, available.  This requires the GObject-Introspection
-               libraries and tools, along with the Python interpretor that was
+               libraries and tools, along with the Python interpreter that was
                used during the build of GObject-Introspection.  Please see
                $(srcroot)\README.python for more related details.  This implies
                the build of the HarfBuzz-GObject DLL, along with GLib support.
@@ -63,7 +63,11 @@ CAIRO_FT: Enable the build of the hb-view tool, which makes use of Cairo, and
 
 GRAPHITE2: Enable the Graphite2 shaper, requires the SIL Graphite2 library.
 
-ICU: Enables the build of ICU Unicode functions. Requires the ICU libraries.
+ICU_BUILTIN: Enables building ICU Unicode functions into the HarfBuzz DLL.
+             Requires the ICU libraries.
+
+ICU: Enables the build of ICU Unicode functions in a separate DLL. Requires
+     the ICU libraries.
 
 UNISCRIBE: Enable Uniscribe platform shaper support.
 
@@ -71,8 +75,8 @@ DIRECTWRITE: Enable DirectWrite platform shaper support,
              requires a rather recent Windows SDK, and at least Windows Vista/
              Server 2008 with SP2 and platform update.
 
-PYTHON: Full path to the Python interpretor to be used, if it is not in %PATH%.
+PYTHON: Full path to the Python interpreter to be used, if it is not in %PATH%.
 
-PERL: Full path to the PERL interpretor to be used, if it is not in %PATH%.
+PERL: Full path to the PERL interpreter to be used, if it is not in %PATH%.
 
 LIBTOOL_DLL_NAME: Enable libtool-style DLL names.

--- a/win32/config-msvc.mak
+++ b/win32/config-msvc.mak
@@ -181,6 +181,20 @@ HB_TESTS = \
 	$(CFG)\$(PLAT)\test-unicode.exe				\
 	$(CFG)\$(PLAT)\test-version.exe
 
+!elseif "$(ICU_BUILTIN)" == "1"
+# use ICU for Unicode functions
+# and define some of the macros in GLib's msvc_recommended_pragmas.h
+# to reduce some unneeded build-time warnings
+HB_DEFINES = $(HB_DEFINES) /DHAVE_ICU=1 /DHAVE_ICU_BUILTIN=1
+HB_CFLAGS =	\
+	$(HB_CFLAGS)					\
+	/wd4244							\
+	/D_CRT_SECURE_NO_WARNINGS		\
+	/D_CRT_NONSTDC_NO_WARNINGS
+
+HB_SOURCES = $(HB_SOURCES) $(HB_ICU_sources)
+HB_HEADERS = $(HB_HEADERS) $(HB_ICU_headers)
+HB_DEP_LIBS = $(HB_DEP_LIBS) $(HB_ICU_DEP_LIBS)
 !else
 # If there is no GLib support, use the built-in UCDN
 # and define some of the macros in GLib's msvc_recommended_pragmas.h

--- a/win32/detectenv-msvc.mak
+++ b/win32/detectenv-msvc.mak
@@ -110,7 +110,9 @@ VALID_CFGSET = TRUE
 # the resulting binaries
 !if "$(CFG)" == "release"
 CFLAGS_ADD = /MD /O2 /GL /MP
-!if "$(VSVER)" != "9"
+!if $(VSVER) > 9 && $(VSVER) < 14
+# Undocumented "enhance optimized debugging" switch. Became documented
+# as "/Zo" in VS 2013 Update 3, and is turned on by default in VS 2015.
 CFLAGS_ADD = $(CFLAGS_ADD) /d2Zi+
 !endif
 !else

--- a/win32/info-msvc.mak
+++ b/win32/info-msvc.mak
@@ -11,6 +11,8 @@ BUILT_TOOLS = hb-shape.exe hb-ot-shape-closure.exe
 !if "$(CAIRO_FT)" == "1"
 BUILT_TOOLS = hb-view.exe $(BUILT_TOOLS)
 !endif
+!elseif "$(ICU_BUILTIN)" == "1"
+UNICODE_IMPL = ICU
 !else
 UNICODE_IMPL = ucdn
 !endif
@@ -104,17 +106,21 @@ help:
 	@echo Enable the HarfBuzz-ICU layout library, requires the International
 	@echo Components for Unicode (ICU) libraries.
 	@echo.
+	@echo ICU_BUILTIN:
+	@echo Enable ICU as default Unicode implementation for the HarfBuzz DLL,
+	@echo requires the International Components for Unicode (ICU) libraries.
+	@echo.
 	@echo GOBJECT:
 	@echo Enable the HarfBuzz-GObject library, also implies GLib2 support,
 	@echo requires the GNOME GLib2 libraries and tools, notably the glib-mkenums
-	@echo tool script, which will require a PERL interpretor (use
+	@echo tool script, which will require a PERL interpreter (use
 	@echo PERL=^$(PATH_TO_PERL_INTERPRETOR)) if it is not already in your PATH).
 	@echo.
 	@echo INTROSPECTION:
 	@echo Enable the build of introspection files, also implies GObject/GLib2 support,
 	@echo requires the GNOME gobject-introspection libraries and tools.  You will need
 	@echo to ensure the pkg-config (.pc) files can be found for GObject-2.0 and the
-	@echo Python interpretor (that was used to build the gobject-introsoection tools)
+	@echo Python interpreter (that was used to build the gobject-introspection tools)
 	@echo can be found by setting PKG_CONFIG_PATH beforehand, and passing in PYTHON=
 	@echo ^$(PATH_TO_PYTHON_INTERPRETOR) respectively, if python.exe is not already
 	@echo in your PATH.


### PR DESCRIPTION
I'm not sure when or why it would be sensible to build ICU support in a separate DLL on Windows. So I've left the old "ICU" build option, which did just that, alone, and added a new option "ICU_BUILTIN" for single-DLL builds.

Also fixed a few spelling mistakes, and commented a weird CFLAGS choice.