### PR TITLE
Compilation Error for ASSERT_STATIC on Some Compilers

### DIFF
--- a/src/hb-open-type-private.hh
+++ b/src/hb-open-type-private.hh
@@ -104,9 +104,15 @@ static inline Type& StructAfter(TObject &X)
   static const unsigned int min_size = (size); \
   inline unsigned int get_size (void) const { return (size); }
 
+#if defined(__ghs)
+#define DEFINE_SIZE_UNION(size, _member) \
+  DEFINE_INSTANCE_ASSERTION (sizeof(this->u._member) == (size)); \
+  static const unsigned int min_size = (size)
+#else
 #define DEFINE_SIZE_UNION(size, _member) \
   DEFINE_INSTANCE_ASSERTION (this->u._member.static_size == (size)); \
   static const unsigned int min_size = (size)
+#endif
 
 #define DEFINE_SIZE_MIN(size) \
   DEFINE_INSTANCE_ASSERTION (sizeof (*this) >= (size)); \

--- a/src/hb-open-type-private.hh
+++ b/src/hb-open-type-private.hh
@@ -104,15 +104,9 @@ static inline Type& StructAfter(TObject &X)
   static const unsigned int min_size = (size); \
   inline unsigned int get_size (void) const { return (size); }
 
-#if defined(__ghs)
 #define DEFINE_SIZE_UNION(size, _member) \
-  DEFINE_INSTANCE_ASSERTION (sizeof(this->u._member) == (size)); \
+  DEFINE_INSTANCE_ASSERTION (0*sizeof(this->u._member.static_size) + sizeof(this->u._member) == (size)); \
   static const unsigned int min_size = (size)
-#else
-#define DEFINE_SIZE_UNION(size, _member) \
-  DEFINE_INSTANCE_ASSERTION (this->u._member.static_size == (size)); \
-  static const unsigned int min_size = (size)
-#endif
 
 #define DEFINE_SIZE_MIN(size) \
   DEFINE_INSTANCE_ASSERTION (sizeof (*this) >= (size)); \


### PR DESCRIPTION
The `DEFINE_SIZE_UNION` macro ultimately resolves to an `inline` function, in which the macro `ASSERT_STATIC` is expanded. In `ASSERT_STATIC`, the this pointer is used in a `typedef` expression. In the C++ standard, it is not completely specified exactly when the `this` pointer can be used in a constant expression. The `typedef` in `ASSERT_STATIC`, which is the basis for the custom static assertion, will not be accepted by the compiler if the array size is not a compile time constant. This can happen if the `this` pointer is not regarded as a constant.
With the GNU compilers the `this` pointer is allowed to be a constant in expressions when a `const` specifier is added to a member function of a class or a struct. With clang and the `-pedantic-errors` flag this is not the case. With the Green Hills Compiler, this is not the case as well.
This patch aims to apply a workaround for the explained problem. The `(sizeof(this->u._member) == (size))` expression is equivalent to the original expression, because `DEFINE_SIZE_STATIC` expands to `DEFINE_INSTANCE_ASSERTION (sizeof (*this) == (size))\ ... `.