### PR TITLE
hb-font: Fix a potentially undefined use of memcmp()

### DIFF
--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -1596,7 +1596,8 @@ _hb_font_adopt_var_coords_normalized (hb_font_t *font,
 				      unsigned int coords_length)
 {
   if (font->num_coords == coords_length &&
-      0 == memcmp (font->coords, coords, coords_length * sizeof (coords[0])))
+      (coords_length == 0 ||
+       0 == memcmp (font->coords, coords, coords_length * sizeof (coords[0]))))
   {
     free (coords);
     return;


### PR DESCRIPTION
While it’s fine to call memcmp(x, 0, 0) in practice, the C99 standard
explicitly says that this is not allowed: even if the length is zero,
the pointer arguments must be valid.

http://stackoverflow.com/a/16363034

Coverity ID: 141178

Signed-off-by: Philip Withnall <withnall@endlessm.com>