### PR TITLE
Fix for reordering of Tibetan vowel u

### DIFF
--- a/src/hb-unicode-private.hh
+++ b/src/hb-unicode-private.hh
@@ -345,9 +345,7 @@ extern HB_INTERNAL const hb_unicode_funcs_t _hb_unicode_funcs_nil;
 #define HB_MODIFIED_COMBINING_CLASS_CCC118 118 /* sign u / sign uu */
 #define HB_MODIFIED_COMBINING_CLASS_CCC122 122 /* mai * */
 
-/* Tibetan
- * Modify U+0F74 (ccc=132) to reorder before ccc=130 marks.
- */
+/* Tibetan */
 #define HB_MODIFIED_COMBINING_CLASS_CCC129 129 /* sign aa */
 #define HB_MODIFIED_COMBINING_CLASS_CCC130 130 /* sign i */
 #define HB_MODIFIED_COMBINING_CLASS_CCC132 132 /* sign u */

--- a/src/hb-unicode-private.hh
+++ b/src/hb-unicode-private.hh
@@ -345,10 +345,17 @@ extern HB_INTERNAL const hb_unicode_funcs_t _hb_unicode_funcs_nil;
 #define HB_MODIFIED_COMBINING_CLASS_CCC118 118 /* sign u / sign uu */
 #define HB_MODIFIED_COMBINING_CLASS_CCC122 122 /* mai * */
 
-/* Tibetan */
+/* Tibetan
+ * 
+ * In case of multiple vowel-signs, use u first (but after achung) 
+ * this allows Dzongkha multi-vowel shortcuts to render correctly 
+ */
 #define HB_MODIFIED_COMBINING_CLASS_CCC129 129 /* sign aa */
-#define HB_MODIFIED_COMBINING_CLASS_CCC130 130 /* sign i */
-#define HB_MODIFIED_COMBINING_CLASS_CCC132 132 /* sign u */
+#define HB_MODIFIED_COMBINING_CLASS_CCC130 132 /* sign i */
+#define HB_MODIFIED_COMBINING_CLASS_CCC132 131 /* sign u */
+#define HB_MODIFIED_COMBINING_CLASS_CCC138 138 /* sign e */
+#define HB_MODIFIED_COMBINING_CLASS_CCC140 140 /* sign o */
+
 
 
 /* Misc */

--- a/src/hb-unicode-private.hh
+++ b/src/hb-unicode-private.hh
@@ -350,7 +350,7 @@ extern HB_INTERNAL const hb_unicode_funcs_t _hb_unicode_funcs_nil;
  */
 #define HB_MODIFIED_COMBINING_CLASS_CCC129 129 /* sign aa */
 #define HB_MODIFIED_COMBINING_CLASS_CCC130 130 /* sign i */
-#define HB_MODIFIED_COMBINING_CLASS_CCC132 128 /* sign u */
+#define HB_MODIFIED_COMBINING_CLASS_CCC132 132 /* sign u */
 
 
 /* Misc */

--- a/src/hb-unicode-private.hh
+++ b/src/hb-unicode-private.hh
@@ -353,10 +353,6 @@ extern HB_INTERNAL const hb_unicode_funcs_t _hb_unicode_funcs_nil;
 #define HB_MODIFIED_COMBINING_CLASS_CCC129 129 /* sign aa */
 #define HB_MODIFIED_COMBINING_CLASS_CCC130 132 /* sign i */
 #define HB_MODIFIED_COMBINING_CLASS_CCC132 131 /* sign u */
-#define HB_MODIFIED_COMBINING_CLASS_CCC138 138 /* sign e */
-#define HB_MODIFIED_COMBINING_CLASS_CCC140 140 /* sign o */
-
-
 
 /* Misc */
 


### PR DESCRIPTION
Following the discoveries of @eroux, discussion in #417, this minimal change to 2f560ee44b7b08683e8e6955fe3b95187e8bda32 seems to fix the rendering of long Tibetan vowel U, fixes #417.