### PR TITLE
NMake Makefiles: Fix ICU builds

### DIFF
--- a/win32/config-msvc.mak
+++ b/win32/config-msvc.mak
@@ -42,6 +42,7 @@ HB_SOURCES =	\
 	$(HB_OT_sources)			\
 	$(HB_OT_RAGEL_GENERATED_sources)
 
+
 HB_HEADERS =	\
 	$(HB_BASE_headers)		\
 	$(HB_NODIST_headers)	\
@@ -177,6 +178,17 @@ HB_TESTS = \
 	$(CFG)\$(PLAT)\test-version.exe
 
 !else
+
+# Define some of the macros in GLib's msvc_recommended_pragmas.h
+# to reduce some unneeded build-time warnings
+HB_CFLAGS =	\
+	$(HB_CFLAGS)			\
+	/wd4244				\
+	/D_CRT_SECURE_NO_WARNINGS	\
+	/D_CRT_NONSTDC_NO_WARNINGS
+
+!endif
+
 !if "$(ICU)" == "1"
 # use ICU for Unicode functions
 # and define some of the macros in GLib's msvc_recommended_pragmas.h
@@ -192,16 +204,6 @@ HB_CFLAGS =	$(HB_CFLAGS) /DU_HAVE_INT8_T
 HB_SOURCES = $(HB_SOURCES) $(HB_ICU_sources)
 HB_HEADERS = $(HB_HEADERS) $(HB_ICU_headers)
 HB_DEP_LIBS = $(HB_DEP_LIBS) $(HB_ICU_DEP_LIBS)
-!endif
-
-# Define some of the macros in GLib's msvc_recommended_pragmas.h
-# to reduce some unneeded build-time warnings
-HB_CFLAGS =	\
-	$(HB_CFLAGS)			\
-	/wd4244				\
-	/D_CRT_SECURE_NO_WARNINGS	\
-	/D_CRT_NONSTDC_NO_WARNINGS
-
 !endif
 
 !if "$(UNISCRIBE)" == "1"

--- a/win32/detectenv-msvc.mak
+++ b/win32/detectenv-msvc.mak
@@ -87,8 +87,10 @@ VSVER = 10
 VSVER = 11
 !elseif $(VCVERSION) > 1799 && $(VCVERSION) < 1900
 VSVER = 12
-!elseif $(VCVERSION) > 1899 && $(VCVERSION) < 2000
+!elseif $(VCVERSION) > 1899 && $(VCVERSION) < 1910
 VSVER = 14
+!elseif $(VCVERSION) > 1909 && $(VCVERSION) < 2000
+VSVER = 15
 !else
 VSVER = 0
 !endif

--- a/win32/info-msvc.mak
+++ b/win32/info-msvc.mak
@@ -6,17 +6,21 @@ BUILT_LIBRARIES = HarfBuzz
 
 !if "$(NO_UCDN)" != "1"
 UNICODE_IMPL = ucdn
-!else
-!if "$(GLIB)" == "1"
+!elseif "$(GLIB)" == "1"
 UNICODE_IMPL = GLib
+!elseif "$(ICU)" == "1"
+UNICODE_IMPL = ICU
+!endif
+
+!if "$(GLIB)" == "1"
 INC_FEATURES = $(INC_FEATURES) GLib
 BUILT_TOOLS = hb-shape.exe hb-ot-shape-closure.exe
 !if "$(CAIRO_FT)" == "1"
 BUILT_TOOLS = hb-view.exe $(BUILT_TOOLS)
 !endif
-!elseif "$(ICU)" == "1"
-UNICODE_IMPL = ICU
 !endif
+!if "$(ICU)" == "1"
+INC_FEATURES = $(INC_FEATURES) ICU
 !endif
 
 !if "$(FREETYPE)" == "1"


### PR DESCRIPTION
Hi,

The check conditions in the NMake Makefiles need to be re-ordered so that we can ensure that the ICU items are indeed built into the HarfBuzz DLL when UCDN is enabled (and the build info shows as such).  This also updates the NMake Makefiles to detect that we are using Visual Studio 2017.

With blessings, thank you!