### PR TITLE
[cmake] Remove NO_MT flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ include_directories(AFTER
 
 # feel free to discuss these or more with the maintainers
 add_definitions(-DHAVE_OT)
-add_definitions(-DHB_NO_MT)
 add_definitions(-DHB_DISABLE_DEPRECATED)
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
Is this logic sounds right to you or it should be better be like "if (HB_HAVE_GLIB OR HB_HAVE_ICU)" and maybe HB_HAVE_CORETEXT and other OS provided APIs also?

(With having this in mind that the goal of this cmake is I think to be a simple but correct (thats why I removed -DHB_NO_UNICODE_FUNCS) and easily embeddable harfbuzz distribution that maybe replaces third party distributions like [these](https://www.google.com/search?q=cmake+harfbuzz), and our internal nmake win32 port also entirely someday, if @fanc999 agrees also, other than my personal goal that is making harfbuzz development itself easier with OS provided Xcode or VS tools and extra APIs/SDKs.)