### PR TITLE
[cmake] Add atomic ops availability detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,36 @@ endif ()
 set(project_sources ${project_sources} ${project_headers})
 ##
 
+## Atomic ops availability detection
+file(WRITE "${PROJECT_BINARY_DIR}/try_compile_intel_atomic_primitives.c"
+"		void memory_barrier (void) { __sync_synchronize (); }
+		int atomic_add (int *i) { return __sync_fetch_and_add (i, 1); }
+		int mutex_trylock (int *m) { return __sync_lock_test_and_set (m, 1); }
+		void mutex_unlock (int *m) { __sync_lock_release (m); }
+")
+try_compile(HB_HAVE_INTEL_ATOMIC_PRIMITIVES
+  ${PROJECT_BINARY_DIR}/try_compile_intel_atomic_primitives
+  SOURCES ${PROJECT_BINARY_DIR}/try_compile_intel_atomic_primitives.c)
+if (HB_HAVE_INTEL_ATOMIC_PRIMITIVES)
+  add_definitions(-DHAVE_INTEL_ATOMIC_PRIMITIVES)
+endif ()
+
+file(WRITE "${PROJECT_BINARY_DIR}/try_compile_solaris_atomic_ops.c"
+"		#include <atomic.h>
+		/* This requires Solaris Studio 12.2 or newer: */
+		#include <mbarrier.h>
+		void memory_barrier (void) { __machine_rw_barrier (); }
+		int atomic_add (volatile unsigned *i) { return atomic_add_int_nv (i, 1); }
+		void *atomic_ptr_cmpxchg (volatile void **target, void *cmp, void *newval) { return atomic_cas_ptr (target, cmp, newval); }
+")
+try_compile(HB_HAVE_SOLARIS_ATOMIC_OPS
+  ${PROJECT_BINARY_DIR}/try_compile_solaris_atomic_ops
+  SOURCES ${PROJECT_BINARY_DIR}/try_compile_solaris_atomic_ops.c)
+if (HB_HB_HAVE_SOLARIS_ATOMIC_OPS)
+  add_definitions(-DHB_HAVE_SOLARIS_ATOMIC_OPS)
+endif ()
+##
+
 add_library(harfbuzz ${project_sources})
 target_link_libraries(harfbuzz ${THIRD_PARTY_LIBS})
 


### PR DESCRIPTION
Adopted from https://github.com/tamaskenez/harfbuzz-cmake/blob/master/CMakeLists.txt#L130-L150 which is originally is from harfuzz's configure.ac