### PR TITLE
[cmake] Remove HB_DISABLE_DEPRECATED as it seems needed for pango build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,7 @@ include_directories(AFTER
   ${PROJECT_BINARY_DIR}/src
   )
 
-# feel free to discuss these or more with the maintainers
 add_definitions(-DHAVE_OT)
-add_definitions(-DHB_DISABLE_DEPRECATED)
 
 if (BUILD_SHARED_LIBS)
   add_definitions(-DHAVE_ATEXIT)


### PR DESCRIPTION
See https://github.com/Microsoft/vcpkg/pull/943#issuecomment-294447460