### PR TITLE
Fix clang -Wcomma warnings (#471)

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -186,8 +186,10 @@ lang_equal (hb_language_t  v1,
   const unsigned char *p1 = (const unsigned char *) v1;
   const unsigned char *p2 = (const unsigned char *) v2;
 
-  while (*p1 && *p1 == canon_map[*p2])
-    p1++, p2++;
+  while (*p1 && *p1 == canon_map[*p2]) {
+    p1++;
+    p2++;
+  }
 
   return *p1 == canon_map[*p2];
 }

--- a/src/hb-ot-layout-gsubgpos-private.hh
+++ b/src/hb-ot-layout-gsubgpos-private.hh
@@ -342,7 +342,7 @@ struct hb_apply_context_t :
     inline void init (hb_apply_context_t *c_, bool context_match = false)
     {
       c = c_;
-      match_glyph_data = NULL,
+      match_glyph_data = NULL;
       matcher.set_match_func (NULL, NULL);
       matcher.set_lookup_props (c->lookup_props);
       /* Ignore ZWNJ if we are matching GSUB context, or matching GPOS. */

--- a/src/hb-shape-plan.cc
+++ b/src/hb-shape-plan.cc
@@ -431,11 +431,12 @@ static inline hb_bool_t
 hb_non_global_user_features_present (const hb_feature_t *user_features,
 				     unsigned int        num_user_features)
 {
-  while (num_user_features)
+  while (num_user_features) {
     if (user_features->start != 0 || user_features->end != (unsigned int) -1)
       return true;
-    else
-      num_user_features--, user_features++;
+    num_user_features--;
+    user_features++;
+  }
   return false;
 }
 


### PR DESCRIPTION
clang's new -Wcomma compiler option warns about possible misuse of the
comma operator such as between two statements.

hb-common.cc:190:9 [-Wcomma] possible misuse of comma operator here
hb-ot-layout-gsubgpos-private.hh:345:30 [-Wcomma] possible misuse of
comma operator here
hb-shape-plan.cc:438:26 [-Wcomma] possible misuse of comma operator here