### PR TITLE
Avoid using strdup inside library.

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -221,7 +221,13 @@ struct hb_language_item_t {
   }
 
   inline hb_language_item_t & operator = (const char *s) {
-    lang = (hb_language_t) strdup (s);
+    /* If a custom allocated is used calling strdup() pairs
+    badly with a call to the custom free() in finish() below.
+    Therefore don't call strdup(), implement its behavior.
+    */
+    size_t len = strlen(s) + 1;
+    lang = (hb_language_t) malloc(len);
+    memcpy((unsigned char *) lang, s, len);
     for (unsigned char *p = (unsigned char *) lang; *p; p++)
       *p = canon_map[*p];
 

--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -168,7 +168,6 @@ extern "C" void  hb_free_impl(void *ptr);
 
 #  if defined(_WIN32_WCE)
      /* Some things not defined on Windows CE. */
-#    define strdup _strdup
 #    define vsnprintf _vsnprintf
 #    define getenv(Name) NULL
 #    if _WIN32_WCE < 0x800
@@ -180,9 +179,6 @@ static int errno = 0; /* Use something better? */
 #  endif
 #  if defined(_MSC_VER) && _MSC_VER < 1900
 #    define snprintf _snprintf
-#  elif defined(_MSC_VER) && _MSC_VER >= 1900
-#    /* Covers VC++ Error for strdup being a deprecated POSIX name and to instead use _strdup instead */
-#    define strdup _strdup
 #  endif
 #endif
 


### PR DESCRIPTION
If an application provides a malloc replacement through
hb_malloc_impl() it is important that it is used to allocate
everything, but the use of strdup() circumvents this and
causes system malloc() to be called instead. This pairs
badly with the custom hb_free_impl() being called later.