### PR TITLE
Support branch prediction helpers on clang compiles

### DIFF
--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -74,10 +74,9 @@ extern "C" void  hb_free_impl(void *ptr);
 /* Compiler attributes */
 
 
-#if defined(__GNUC__) && (__GNUC__ > 2) && defined(__OPTIMIZE__)
-#define _HB_BOOLEAN_EXPR(expr) ((expr) ? 1 : 0)
-#define likely(expr) (__builtin_expect (_HB_BOOLEAN_EXPR(expr), 1))
-#define unlikely(expr) (__builtin_expect (_HB_BOOLEAN_EXPR(expr), 0))
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__OPTIMIZE__)
+#define likely(expr) (__builtin_expect (!!(expr), 1))
+#define unlikely(expr) (__builtin_expect (!!(expr), 0))
 #else
 #define likely(expr) (expr)
 #define unlikely(expr) (expr)


### PR DESCRIPTION
And drop GCC 2 support (is that still relevant?)

I was [reading](https://chadaustin.me/2017/05/writing-a-really-really-fast-json-parser/) about [sajson](https://github.com/chadaustin/sajson/blob/3cb7ba16ea6ff9184878f6b77f2899d95c26d270/include/sajson.h#L39) and noticed this seems missing on harfbuzz, hope would be useful.