### PR TITLE
Fix signed/unsigned warning in hb_buffer_diff

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -1925,10 +1925,10 @@ hb_buffer_diff (hb_buffer_t *buffer,
     const hb_glyph_position_t *ref_pos = reference->pos;
     for (unsigned int i = 0; i < count; i++)
     {
-      if (abs (buf_pos->x_advance - ref_pos->x_advance) > position_fuzz ||
-          abs (buf_pos->y_advance - ref_pos->y_advance) > position_fuzz ||
-          abs (buf_pos->x_offset - ref_pos->x_offset) > position_fuzz ||
-          abs (buf_pos->y_offset - ref_pos->y_offset) > position_fuzz)
+      if ((unsigned int) abs (buf_pos->x_advance - ref_pos->x_advance) > position_fuzz ||
+          (unsigned int) abs (buf_pos->y_advance - ref_pos->y_advance) > position_fuzz ||
+          (unsigned int) abs (buf_pos->x_offset - ref_pos->x_offset) > position_fuzz ||
+          (unsigned int) abs (buf_pos->y_offset - ref_pos->y_offset) > position_fuzz)
       {
         result |= HB_BUFFER_DIFF_FLAG_POSITION_MISMATCH;
         break;


### PR DESCRIPTION
Change hb_buffer_diff to explicitly cast result of abs to unsigned when
comparing with position_fuzz to avoid unsafe signed/unsigned comparions
warnings on windows.