### PR TITLE
Fix build of HarfBuzz tools and HarfBuzz-GObject on Visual Studio

### DIFF
--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -504,7 +504,7 @@ typedef enum { /*< flags >*/
 } hb_buffer_diff_flags_t;
 
 /* Compare the contents of two buffers, report types of differences. */
-hb_buffer_diff_flags_t
+HB_EXTERN hb_buffer_diff_flags_t
 hb_buffer_diff (hb_buffer_t *buffer,
 		hb_buffer_t *reference,
 		hb_codepoint_t dottedcircle_glyph,

--- a/win32/Makefile.am
+++ b/win32/Makefile.am
@@ -11,6 +11,8 @@ EXTRA_DIST = \
 	install.mak \
 	introspection-msvc.mak \
 	Makefile.vc \
-	README.txt
+	README.txt \
+	replace.py \
+	sed-enums-srcs.py
 
 -include $(top_srcdir)/git.mk

--- a/win32/README.txt
+++ b/win32/README.txt
@@ -57,8 +57,9 @@ GLIB: Enable GLib support in HarfBuzz, which also uses the GLib unicode
 
 GOBJECT: Enable building the HarfBuzz-GObject DLL, and thus implies GLib
          support.  This requires the GObject libraries and glib-mkenums script,
-         along with PERL to generate the enum sources and headers, which is
-         required for the build.
+         along with Python (when using GObject/GLib 2.53.4 or later) or PERL
+         (when using GObject/GLib 2.53.3 or earlier) to generate the enum
+         sources and headers, which is required for the build.
 
 INTROSPECTION: Enable build of introspection files, for making HarfBuzz
                bindings for other programming languages available, such as

--- a/win32/generate-msvc.mak
+++ b/win32/generate-msvc.mak
@@ -12,13 +12,20 @@ config.h: config.h.win32
 # we are already using PERL, use PERL one-liners.
 !if "$(GOBJECT)" == "1"
 $(HB_GOBJECT_ENUM_GENERATED_SOURCES): ..\src\hb-gobject-enums.h.tmpl ..\src\hb-gobject-enums.cc.tmpl $(HB_ACTUAL_HEADERS)
+	-$(PYTHON) $(PREFIX)\bin\glib-mkenums \
+		--identifier-prefix hb_ --symbol-prefix hb_gobject \
+		--template ..\src\$(@F).tmpl  $(HB_ACTUAL_HEADERS) > $@.tmp
+	for %%f in ($@.tmp) do if %%~zf gtr 0 $(PYTHON) sed-enums-srcs.py --input=$@.tmp --output=$@
+	@-del $@.tmp
+	if not exist $@ \
 	$(PERL) $(PREFIX)\bin\glib-mkenums \
 		--identifier-prefix hb_ --symbol-prefix hb_gobject \
-		--template ..\src\$(@F).tmpl  $(HB_ACTUAL_HEADERS) > $@
-	$(PERL) -p -i.tmp1 -e "s/_t_get_type/_get_type/g" $@
-	$(PERL) -p -i.tmp2 -e "s/_T \(/ (/g" $@
-	@-del $@.tmp1
-	@-del $@.tmp2
+		--template ..\src\$(@F).tmpl  $(HB_ACTUAL_HEADERS) > $@.tmp
+	if exist $@.tmp $(PERL) -p -i.tmp1 -e "s/_t_get_type/_get_type/g" $@.tmp
+	if exist $@.tmp $(PERL) -p -i.tmp2 -e "s/_T \(/ (/g" $@.tmp
+	@if exist $@.tmp.tmp1 del $@.tmp.tmp1
+	@if exist $@.tmp.tmp2 del $@.tmp.tmp2
+	@if exist $@.tmp move $@.tmp $@
 !endif
 
 # Create the build directories

--- a/win32/info-msvc.mak
+++ b/win32/info-msvc.mak
@@ -107,7 +107,10 @@ help:
 	@echo GOBJECT:
 	@echo Enable the HarfBuzz-GObject library, also implies GLib2 support,
 	@echo requires the GNOME GLib2 libraries and tools, notably the glib-mkenums
-	@echo tool script, which will require a PERL interpreter (use
+	@echo tool script, which will require a Python interpretor (when using
+	@echo GObject/GLib 2.53.4 or later; use PYTHON=^$(PATH_TO_PYTHON_INTERPRETOR)
+	@echo if the Python interpretor is not already in your PATH) or PERL
+	@echo interpreter (when using GObject/GLib 2.53.3 or earlier; use
 	@echo PERL=^$(PATH_TO_PERL_INTERPRETOR)) if it is not already in your PATH).
 	@echo.
 	@echo GRAPHITE2:

--- a/win32/replace.py
+++ b/win32/replace.py
@@ -25,7 +25,7 @@ def open_file(filename, mode):
     if sys.version_info[0] < 3:
         return open(filename, mode=mode)
     else:
-        return open(filename, mode=mode, encoding='utf-8')
+        return open(filename, mode=mode, encoding='latin-1')
 
 def replace_multi(src, dest, replace_items):
     with open_file(src, 'r') as s:

--- a/win32/sed-enums-srcs.py
+++ b/win32/sed-enums-srcs.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+#
+# Utility script to replace strings in the
+# generated enum sources, as needed by the build
+
+# Author: Fan, Chun-wei
+# Date: Oct. 5, 2017
+
+import os
+import sys
+import argparse
+
+from replace import replace_multi
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='Replace strings in generated enum sources')
+    parser.add_argument('--input', help='input generated temporary enum source',
+                        required=True)
+    parser.add_argument('--output',
+                        help='output generated final enum source', required=True)
+    args = parser.parse_args()
+
+    # check whether the generated temporary enum source exists
+    if not os.path.exists(args.input):
+        raise SystemExit('Specified generated temporary enum source \'%s\' is invalid' % args.input)
+
+    replace_items = {'_t_get_type': '_get_type',
+                     '_T (': ' ('}
+
+    # Generate the final enum source
+    replace_multi(args.input,
+                  args.output,
+                  replace_items)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Hi,

When building the HarfBuzz tools, a recently-added symbol, hb_buffer_diff(), was not marked with HB_EXTERN, so that symbol was not exported from the HarfBuzz DLL when building with Visual Studio, causing tools builds to fail, so I attached a simple patch to fix this.

On the other hand, since GLib 2.53.4 and later had glib-mkenums ported to Python, we have to change how the enum sources for HarfBuzz-GObject is generated.  The issue is, since the cmd.exe (which NMake builds run on) do not supported shebang lines, we need to first test-run glib-mkenums with Python, and fall back to PERL if that fails (and bail out if that fails as well), and use a simple Python script or PERL one-liners to do the necessary string replacements in the generated enum sources depending on whether Python or PERL was successfully used for running glib-mkenums.

With blessings, thank you!