### PR TITLE
[ot-font] Implement reading glyph names

### DIFF
--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -327,6 +327,15 @@ struct hb_ot_face_post_accelerator_t
 
     return this->post->get_glyph_name (glyph, name, size, this->post_len);
   }
+
+  inline bool get_glyph_from_name (const char *name, int len,
+                                   hb_codepoint_t *glyph) const
+  {
+    if (unlikely (!name) || unlikely(!len))
+      return false;
+
+    return this->post->get_glyph_from_name (name, len, glyph, this->post_len);
+  }
 };
 
 typedef bool (*hb_cmap_get_glyph_func_t) (const void *obj,
@@ -578,6 +587,17 @@ hb_ot_get_glyph_name (hb_font_t *font HB_UNUSED,
 }
 
 static hb_bool_t
+hb_ot_get_glyph_from_name (hb_font_t *font HB_UNUSED,
+                           void *font_data,
+                           const char *name, int len,
+                           hb_codepoint_t *glyph,
+                           void *user_data HB_UNUSED)
+{
+  const hb_ot_font_t *ot_font = (const hb_ot_font_t *) font_data;
+  return ot_font->post->get_glyph_from_name (name, len, glyph);
+}
+
+static hb_bool_t
 hb_ot_get_font_h_extents (hb_font_t *font HB_UNUSED,
 			  void *font_data,
 			  hb_font_extents_t *metrics,
@@ -638,7 +658,7 @@ retry:
     hb_font_funcs_set_glyph_extents_func (funcs, hb_ot_get_glyph_extents, nullptr, nullptr);
     //hb_font_funcs_set_glyph_contour_point_func (funcs, hb_ot_get_glyph_contour_point, nullptr, nullptr); TODO
     hb_font_funcs_set_glyph_name_func (funcs, hb_ot_get_glyph_name, nullptr, nullptr);
-    //hb_font_funcs_set_glyph_from_name_func (funcs, hb_ot_get_glyph_from_name, nullptr, nullptr); TODO
+    hb_font_funcs_set_glyph_from_name_func (funcs, hb_ot_get_glyph_from_name, nullptr, nullptr);
 
     hb_font_funcs_make_immutable (funcs);
 

--- a/test/shaping/tests/fallback-positioning.tests
+++ b/test/shaping/tests/fallback-positioning.tests
@@ -1,2 +1,2 @@
 fonts/sha1sum/7ef276fc886ea502a03b9b0e5c8b547d5dc2b61c.ttf:--font-funcs=ft:U+0078,U+0301,U+0058,U+0301:[x=0+1030|acutecomb=0@-45,-32+0|X=2+1295|acutecomb=2@-171,310+0]
-fonts/sha1sum/7ef276fc886ea502a03b9b0e5c8b547d5dc2b61c.ttf:--font-funcs=ot:U+0078,U+0301,U+0058,U+0301:[gid2=0+1030|gid4=0@-21,-27+0|gid1=2+1295|gid4=2@-147,321+0]
+fonts/sha1sum/7ef276fc886ea502a03b9b0e5c8b547d5dc2b61c.ttf:--font-funcs=ot:U+0078,U+0301,U+0058,U+0301:[x=0+1030|acutecomb=0@-21,-27+0|X=2+1295|acutecomb=2@-147,321+0]

--- a/test/shaping/tests/indic-syllable.tests
+++ b/test/shaping/tests/indic-syllable.tests
@@ -1,7 +1,7 @@
 fonts/sha1sum/54674a3111d209fb6be0ed31745314b7a8d2c244.ttf::U+0BA4,U+0BCD,U+00B3:[taprehalftamil=0+1509|uni00B3=2+674]
 fonts/sha1sum/3d0b77a2360aa6faa1385aaa510509ab70dfbeff.ttf::U+0CF1:[gid1=0+1129]
 fonts/sha1sum/3d0b77a2360aa6faa1385aaa510509ab70dfbeff.ttf::U+0CF2:[gid2=0+1539]
-fonts/sha1sum/87f85d17d26f1fe9ad28d7365101958edaefb967.ttf:--font-funcs=ot:U+0980,U+0981:[gid1=0+520|gid2=0+0]
+fonts/sha1sum/87f85d17d26f1fe9ad28d7365101958edaefb967.ttf:--font-funcs=ot:U+0980,U+0981:[anjibeng=0+520|candrabindubeng=0+0]
 fonts/sha1sum/85fe0be440c64ac77699e21c2f1bd933a919167e.ttf::U+0A15,U+0A51,U+0A47:[kaguru=0+1273|udaatguru=0@75,0+0|eematraguru=0@-40,0+0]
 fonts/sha1sum/1735326da89f0818cd8c51a0600e9789812c0f94.ttf::U+0A51:[uni25CC=0+1044|udaatguru=0+0]
 fonts/sha1sum/1735326da89f0818cd8c51a0600e9789812c0f94.ttf::U+25CC,U+0A51:[uni25CC=0+1044|udaatguru=0+0]

--- a/test/shaping/tests/use.tests
+++ b/test/shaping/tests/use.tests
@@ -1,4 +1,4 @@
 fonts/sha1sum/fbb6c84c9e1fe0c39e152fbe845e51fd81f6748e.ttf::U+1B1B,U+1B44,U+1B13,U+1B3E:[gid3=0+990|gid7=0+2473|gid5=0@-293,-400+0]
 fonts/sha1sum/4cce528e99f600ed9c25a2b69e32eb94a03b4ae8.ttf::U+1A48,U+1A58,U+1A25,U+1A48,U+1A58,U+1A25,U+1A6E,U+1A63:[uni1A48=0+1212|uni1A25=0+1912|uni1A58=0+0|uni1A48=3+1212|uni1A6E=3+0|uni1A25=3+1912|uni1A58=3+0|uni1A63=3+1212]
 fonts/sha1sum/f518eb6f6b5eec2946c9fbbbde44e45d46f5e2ac.ttf::U+1A48,U+1A58,U+1A25,U+1A48,U+1A58,U+1A25,U+1A6E,U+1A63:[uni1A48=0+1212|uni1A25=0+1912|uni1A58=0+0|uni1A48=3+1212|uni1A6E=3+1211|uni1A25=3+1912|uni1A58=3+0|uni1A63=3+1212]
-fonts/sha1sum/6ff0fbead4462d9f229167b4e6839eceb8465058.ttf:--font-funcs=ot:U+11103,U+11128:[gid1=0+837|gid2=0+0]
+fonts/sha1sum/6ff0fbead4462d9f229167b4e6839eceb8465058.ttf:--font-funcs=ot:U+11103,U+11128:[u11103=0+837|u11128=0+0]


### PR DESCRIPTION
Turns out we already have support for “post” table, it just needed to be activated and put in use.

Might not be the best way to handle this, as I don’t really think I totally understand how parsing tables in HarfBuzz works.