### PR TITLE
Use `mktemp -d` instead of `mktemp --directory`

### DIFF
--- a/test/shaping/record-test.sh
+++ b/test/shaping/record-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-dir=`mktemp --directory`
+dir=`mktemp -d`
 
 hb_shape=$1
 shift


### PR DESCRIPTION
`--directory` doesn’t work in the macOS version of mktemp. `-d` is more portable.