### PR TITLE
Extend hb_set test for issue 579, and fix broken hb_set operations

### DIFF
--- a/src/hb-set-private.hh
+++ b/src/hb-set-private.hh
@@ -313,13 +313,13 @@ struct hb_set_t
     b = nb;
     for (; a && b; )
     {
-      if (page_map[a].major == other->page_map[b].major)
+      if (page_map[a - 1].major == other->page_map[b - 1].major)
       {
 	a--;
 	b--;
         Op::process (page_at (--count).v, page_at (a).v, other->page_at (b).v);
       }
-      else if (page_map[a].major > other->page_map[b].major)
+      else if (page_map[a - 1].major > other->page_map[b - 1].major)
       {
         a--;
         if (Op::passthru_left)

--- a/test/api/test-set.c
+++ b/test/api/test-set.c
@@ -188,6 +188,24 @@ test_set_algebra (void)
   g_assert (hb_set_has (o, 888));
   g_assert (hb_set_has (o, 889));
 
+  hb_set_clear (s);
+  test_empty (s);
+  hb_set_add_range (s, 886, 895);
+  hb_set_add (s, 1014);
+  hb_set_add (s, 1017);
+  hb_set_add (s, 1024);
+  hb_set_add (s, 1113);
+  hb_set_add (s, 1121);
+  g_assert_cmpint (hb_set_get_population (s), ==, 15);
+
+  hb_set_clear (o);
+  test_empty (o);
+  hb_set_add (o, 889);
+  g_assert_cmpint (hb_set_get_population (o), ==, 1);
+  hb_set_intersect (o, s);
+  g_assert_cmpint (hb_set_get_population (o), ==, 1);
+  g_assert (hb_set_has (o, 889));
+
   hb_set_destroy (s);
   hb_set_destroy (o);
 }


### PR DESCRIPTION
The inputs I reported in this issue were incomplete, as it turns out -- they were derived by using hb_set_next to enumerate the contents of the sets in question, but that was itself broken! So here's a complete example that fails with the 1.6.2 implementation of hb_set (but passed previously).

Obviously, this can't be merged right now as it'll make the test fail.