### PR TITLE
Bugfix for iteration with hb_set_next, and add failing case to hb_set tests

### DIFF
--- a/src/hb-set-private.hh
+++ b/src/hb-set-private.hh
@@ -95,7 +95,7 @@ struct hb_set_t
 	  goto found;
       for (i++; i < len (); i++)
         if (v[i])
-	  for (unsigned int j = 0; j < ELT_BITS; j++)
+	  for (j = 0; j < ELT_BITS; j++)
 	    if (v[i] & (elt_t (1) << j))
 	      goto found;
 

--- a/test/api/test-set.c
+++ b/test/api/test-set.c
@@ -201,6 +201,8 @@ test_set_iter (void)
   hb_set_add (s, 13);
   hb_set_add_range (s, 6, 6);
   hb_set_add_range (s, 10, 15);
+  hb_set_add (s, 1100);
+  hb_set_add (s, 1200);
   hb_set_add (s, 20005);
 
   test_not_empty (s);
@@ -218,6 +220,10 @@ test_set_iter (void)
   g_assert (hb_set_next (s, &next));
   g_assert_cmpint (next, ==, 15);
   g_assert (hb_set_next (s, &next));
+  g_assert_cmpint (next, ==, 1100);
+  g_assert (hb_set_next (s, &next));
+  g_assert_cmpint (next, ==, 1200);
+  g_assert (hb_set_next (s, &next));
   g_assert_cmpint (next, ==, 20005);
   g_assert (!hb_set_next (s, &next));
   g_assert_cmpint (next, ==, HB_SET_VALUE_INVALID);
@@ -229,6 +235,12 @@ test_set_iter (void)
   g_assert (hb_set_next_range (s, &first, &last));
   g_assert_cmpint (first, ==, 10);
   g_assert_cmpint (last,  ==, 15);
+  g_assert (hb_set_next_range (s, &first, &last));
+  g_assert_cmpint (first, ==, 1100);
+  g_assert_cmpint (last,  ==, 1100);
+  g_assert (hb_set_next_range (s, &first, &last));
+  g_assert_cmpint (first, ==, 1200);
+  g_assert_cmpint (last,  ==, 1200);
   g_assert (hb_set_next_range (s, &first, &last));
   g_assert_cmpint (first, ==, 20005);
   g_assert_cmpint (last,  ==, 20005);


### PR DESCRIPTION
This fixes the bug that led to confusion about the sets involved in issue 579, because `hb_set_next` was returning incorrect results, leading to wrongly-printed set contents.

The breakage occurs when `hb_set_t::next` needs to cross a page boundary, because the new declaration of `j` in the inner loop here in `hb_set_t::page_t::next` goes out of scope when we exit with `goto found`, and we then return a result based on `j == ELT_BITS` from the termination of the preceding loop.