### PR TITLE
Include all relevant glyphs when subsetting a font for testing

### DIFF
--- a/test/shaping/record-test.sh
+++ b/test/shaping/record-test.sh
@@ -41,6 +41,7 @@ if test $? != 0; then
 	echo "hb-shape failed." >&2
 	exit 2
 fi
+glyph_names=`echo "$text" | $hb_shape $options --no-clusters --no-positions "$fontfile" | sed 's/[][]//g; s/|/,/g'`
 
 cp "$fontfile" "$dir/font.ttf"
 fonttools subset \
@@ -48,6 +49,7 @@ fonttools subset \
 	--no-hinting \
 	--layout-features='*' \
 	"$dir/font.ttf" \
+	--glyphs="$glyph_names" \
 	--text="$text"
 if ! test -s "$dir/font.subset.ttf"; then
 	echo "Subsetter didn't produce nonempty subset font in $dir/font.subset.ttf" >&2


### PR DESCRIPTION
record-test.sh subsets the input based on the characters in the input text. pyftsubset only includes glyphs for the characters in the input text, so if the test is of a string where OpenType inserts a dotted circle, the subsetted font will not include a dotted circle. The solution is to use `--glyphs` to tell pyftsubset to include all the glyphs HarfBuzz emits for the input text.