### PR TITLE
[ci] Add CircleCI for cross-compiling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2
+jobs:
+
+  base:
+    docker:
+      - image: dockcross/base
+    steps:
+      - checkout
+      - run: apt update && apt install ragel
+      - run: cmake -Bbuild -H. -GNinja && ninja -Cbuild
+
+  android-arm:
+    docker:
+      - image: dockcross/android-arm
+    steps:
+      - checkout
+      - run: apt update && apt install ragel
+      - run: cmake -Bbuild -H. -GNinja && ninja -Cbuild
+
+  browser-asmjs:
+    docker:
+      - image: dockcross/browser-asmjs
+    steps:
+      - checkout
+      - run: apt update && apt install ragel
+      - run: cmake -Bbuild -H. -GNinja && ninja -Cbuild
+
+  android-arm64:
+    docker:
+      - image: dockcross/android-arm64
+    steps:
+      - checkout
+      - run: apt update && apt install ragel
+      - run: cmake -Bbuild -H. -GNinja && ninja -Cbuild
+
+  linux-mips:
+    docker:
+      - image: dockcross/linux-mips
+    steps:
+      - checkout
+      - run: apt update && apt install ragel
+      - run: cmake -Bbuild -H. -GNinja && ninja -Cbuild
+
+  windows-x64:
+    docker:
+      - image: dockcross/windows-x64
+    steps:
+      - checkout
+      - run: apt update && apt install ragel
+      - run: cmake -Bbuild -H. -GNinja && ninja -Cbuild
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - base
+      - android-arm
+      - browser-asmjs
+      - android-arm64
+      - linux-mips
+      - windows-x64

--- a/README
+++ b/README
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/behdad/harfbuzz.svg)](https://travis-ci.org/behdad/harfbuzz)
 [![Build Status](https://ci.appveyor.com/api/projects/status/4oaq58ns2h0m2soa?svg=true)](https://ci.appveyor.com/project/behdad/harfbuzz)
+[![CircleCI](https://circleci.com/gh/behdad/harfbuzz.svg?style=svg)](https://circleci.com/gh/behdad/harfbuzz)
 [![Coverage Status](https://img.shields.io/coveralls/behdad/harfbuzz.svg)](https://coveralls.io/r/behdad/harfbuzz)
 [ABI Tracker](http://abi-laboratory.pro/tracker/timeline/harfbuzz/)
 


### PR DESCRIPTION
Part of #589

@behdad, you should login into http://circleci.com and enable it for harfbuzz but before that, do you have any idea why this is happening on some compilers? Have a look at [this](https://circleci.com/gh/ebraminio/harfbuzz/tree/master) for more info.

```
[31/41] Building CXX object CMakeFiles/harfbuzz.dir/src/hb-ot-font.cc.o
FAILED: CMakeFiles/harfbuzz.dir/src/hb-ot-font.cc.o 
/usr/arm-linux-androideabi/bin/arm-linux-androideabi-g++ --sysroot=/usr/arm-linux-androideabi/sysroot  -DHAVE_FALLBACK -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHAVE_OT -DHAVE_UCDN -I../src -Isrc -I../src/hb-ucdn  -MD -MT CMakeFiles/harfbuzz.dir/src/hb-ot-font.cc.o -MF CMakeFiles/harfbuzz.dir/src/hb-ot-font.cc.o.d -o CMakeFiles/harfbuzz.dir/src/hb-ot-font.cc.o -c ../src/hb-ot-font.cc
In file included from ../src/hb-ot-post-table.hh:31:0,
                 from ../src/hb-ot-font.cc:41:
../src/hb-sort-r.hh: In function 'void hb_sort_r(void*, size_t, size_t, int (*)(const void*, const void*, void*), void*)':
../src/hb-sort-r.hh:247:46: error: 'qsort_r' was not declared in this scope
         qsort_r(base, nel, width, compar, arg);
                                              ^
```