### PR TITLE
[ci] Add Fedora builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,14 @@ version: 2
 
 jobs:
 
+  fedora:
+    docker:
+      - image: fedora
+    steps:
+      - checkout
+      - run: dnf install -y pkg-config ragel gcc gcc-c++ automake autoconf libtool make which glib2-devel freetype-devel || true
+      - run: ./autogen.sh && make && make check
+
   freebsd9:
     docker:
       - image: donbowman/freebsd-cross-build
@@ -71,6 +79,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - fedora
       - freebsd9
       - base
       - psvita


### PR DESCRIPTION
As https://github.com/behdad/harfbuzz/issues/589#issuecomment-341161406 I thought adding a fedora based compile also would be nice. Unlike others, this does `make check` also.