### PR TITLE
[ci] Add ArchLinux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,16 @@ jobs:
       - image: fedora
     steps:
       - checkout
-      - run: dnf install -y pkg-config ragel gcc gcc-c++ automake autoconf libtool make which glib2-devel freetype-devel || true
-      - run: ./autogen.sh && make && make check
+      - run: dnf install -y pkg-config ragel gcc gcc-c++ automake autoconf libtool make which glib2-devel freetype-devel cairo-devel libicu-devel gobject-introspection-devel graphite2-devel redhat-rpm-config || true
+      - run: ./autogen.sh --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2 && make && make check
+
+  archlinux:
+    docker:
+      - image: base/devel
+    steps:
+      - checkout
+      - run: pacman --noconfirm -Syu freetype2 cairo icu gettext gobject-introspection gcc gcc-libs glib2 graphite pkg-config ragel
+      - run: ./autogen.sh --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2 && make && make check
 
   freebsd9:
     docker:
@@ -80,6 +88,7 @@ workflows:
   build:
     jobs:
       - fedora
+      - archlinux
       - freebsd9
       - base
       - psvita


### PR DESCRIPTION
ArchLinux uses python3 as its default python and always ships brand new compilers and such so it would be interesting to test harfbuzz against it also, see #93 as an ArchLinux specific also that testing harfbuzz could be useful on it.

Also more of harfbuzz backends enabled on Fedora.