### PR TITLE
Simplify tracing code when tracing is disabled.

### DIFF
--- a/src/hb-open-type-private.hh
+++ b/src/hb-open-type-private.hh
@@ -179,10 +179,14 @@ struct hb_dispatch_context_t
 #endif
 
 
+#if HB_DEBUG_SANITIZE == 0
+#define TRACE_SANITIZE(this) hb_no_trace_t<bool> trace;
+#else
 #define TRACE_SANITIZE(this) \
 	hb_auto_trace_t<HB_DEBUG_SANITIZE, bool> trace \
 	(&c->debug_depth, c->get_name (), this, HB_FUNC, \
 	 "");
+#endif
 
 /* This limits sanitizing time on really broken fonts. */
 #ifndef HB_SANITIZE_MAX_EDITS
@@ -392,10 +396,15 @@ struct Sanitizer
 #endif
 
 
+#if HB_DEBUG_SERIALIZE == 0
+#define TRACE_SERIALIZE(this) hb_no_trace_t<bool> trace;
+#else
 #define TRACE_SERIALIZE(this) \
 	hb_auto_trace_t<HB_DEBUG_SERIALIZE, bool> trace \
 	(&c->debug_depth, "SERIALIZE", c, HB_FUNC, \
 	 "");
+#endif
+
 
 
 struct hb_serialize_context_t

--- a/src/hb-ot-layout-common-private.hh
+++ b/src/hb-ot-layout-common-private.hh
@@ -44,11 +44,14 @@
 
 namespace OT {
 
-
+#if (HB_DEBUG_SANITIZE + HB_DEBUG_CLOSURE + HB_DEBUG_WOULD_APPLY + HB_DEBUG_COLLECT_GLYPHS + HB_DEBUG_APPLY) == 0
+#define TRACE_DISPATCH(this, format) hb_no_trace_t<typename context_t::return_t> trace;
+#else
 #define TRACE_DISPATCH(this, format) \
 	hb_auto_trace_t<context_t::max_debug_depth, typename context_t::return_t> trace \
 	(&c->debug_depth, c->get_name (), this, HB_FUNC, \
 	 "format %d", (int) format);
+#endif
 
 
 #define NOT_COVERED		((unsigned int) -1)

--- a/src/hb-ot-layout-gsubgpos-private.hh
+++ b/src/hb-ot-layout-gsubgpos-private.hh
@@ -41,10 +41,15 @@ namespace OT {
 #define HB_DEBUG_CLOSURE (HB_DEBUG+0)
 #endif
 
+#if HB_DEBUG_CLOSURE == 0
+#define TRACE_CLOSURE(this) hb_no_trace_t<hb_void_t> trace;
+#else
 #define TRACE_CLOSURE(this) \
 	hb_auto_trace_t<HB_DEBUG_CLOSURE, hb_void_t> trace \
 	(&c->debug_depth, c->get_name (), this, HB_FUNC, \
 	 "");
+#endif
+
 
 struct hb_closure_context_t :
        hb_dispatch_context_t<hb_closure_context_t, hb_void_t, HB_DEBUG_CLOSURE>
@@ -90,10 +95,14 @@ struct hb_closure_context_t :
 #define HB_DEBUG_WOULD_APPLY (HB_DEBUG+0)
 #endif
 
+#if HB_DEBUG_WOULD_APPLY == 0
+#define TRACE_WOULD_APPLY(this) hb_no_trace_t<bool> trace;
+#else
 #define TRACE_WOULD_APPLY(this) \
 	hb_auto_trace_t<HB_DEBUG_WOULD_APPLY, bool> trace \
 	(&c->debug_depth, c->get_name (), this, HB_FUNC, \
 	 "%d glyphs", c->len);
+#endif
 
 struct hb_would_apply_context_t :
        hb_dispatch_context_t<hb_would_apply_context_t, bool, HB_DEBUG_WOULD_APPLY>
@@ -127,10 +136,14 @@ struct hb_would_apply_context_t :
 #define HB_DEBUG_COLLECT_GLYPHS (HB_DEBUG+0)
 #endif
 
+#if HB_DEBUG_COLLECT_GLYPHS == 0
+#define TRACE_COLLECT_GLYPHS(this) hb_no_trace_t<hb_void_t> trace;
+#else
 #define TRACE_COLLECT_GLYPHS(this) \
 	hb_auto_trace_t<HB_DEBUG_COLLECT_GLYPHS, hb_void_t> trace \
 	(&c->debug_depth, c->get_name (), this, HB_FUNC, \
 	 "");
+#endif
 
 struct hb_collect_glyphs_context_t :
        hb_dispatch_context_t<hb_collect_glyphs_context_t, hb_void_t, HB_DEBUG_COLLECT_GLYPHS>
@@ -254,11 +267,15 @@ struct hb_add_coverage_context_t :
 #define HB_DEBUG_APPLY (HB_DEBUG+0)
 #endif
 
+#if HB_DEBUG_APPLY == 0
+#define TRACE_APPLY(this) hb_no_trace_t<bool> trace;
+#else
 #define TRACE_APPLY(this) \
 	hb_auto_trace_t<HB_DEBUG_APPLY, bool> trace \
 	(&c->debug_depth, c->get_name (), this, HB_FUNC, \
 	 "idx %d gid %u lookup %d", \
 	 c->buffer->idx, c->buffer->cur().codepoint, (int) c->lookup_index);
+#endif
 
 struct hb_apply_context_t :
        hb_dispatch_context_t<hb_apply_context_t, bool, HB_DEBUG_APPLY>

--- a/src/hb-private.hh
+++ b/src/hb-private.hh
@@ -903,15 +903,11 @@ struct hb_auto_trace_t {
   const void *obj;
   bool returned;
 };
-template <typename ret_t> /* Optimize when tracing is disabled */
-struct hb_auto_trace_t<0, ret_t> {
-  explicit inline hb_auto_trace_t (unsigned int *plevel_ HB_UNUSED,
-				   const char *what HB_UNUSED,
-				   const void *obj HB_UNUSED,
-				   const char *func HB_UNUSED,
-				   const char *message HB_UNUSED,
-				   ...) {}
 
+/* When tracing is disabled it is best to use a simpler class to get rid of
+ * code bloat */
+template<typename ret_t>
+struct hb_no_trace_t {
   inline ret_t ret (ret_t v, unsigned int line HB_UNUSED = 0) { return v; }
 };
 


### PR DESCRIPTION
If tracing is disabled, instead of using hb_auto_trace_t<0, ret_t>, a
new struct is used instead hb_no_trace<ret_t>. Using the simpler struct
reduces the binary size for release builds by removing unneaded debug
code.

These are the results of the difference (from chromium build with and without patch):
Section Sizes (Total=-101kb (-103544 bytes)):
    .bss: 0 bytes (0 bytes) (not included in totals)
    .data: 0 bytes (0 bytes) (-0.0%)
    .data.rel.ro: 0 bytes (0 bytes) (-0.0%)
    .rel.dyn: 0 bytes (0 bytes) (-0.0%)
    .rodata: -73.5kb (-75264 bytes) (72.7%)
    .text: -27.6kb (-28280 bytes) (27.3%)

MonochromePublic.apk_Breakdown (-106,496 bytes)
        +2 bytes Zip Overhead
  -106,496 bytes Native code size
        -2 bytes Package metadata size
MonochromePublic.apk_Specifics
  -106,496 bytes normalized apk size
  -106,496 bytes main lib size

For reference the compiled library size in full is 247,609 bytes, in the chrome for android apk.
