### PR TITLE
Trivial typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -809,7 +809,7 @@ Wednesday, July 16, 2014
   U+FFFD REPLACEMENT CHARACTER now.
 - With all changes in this release, the buffer will contain fully
   valid Unicode after hb_buffer_add_utf8/16/32 no matter how
-  broken the input is.  This can be overriden though.  See below.
+  broken the input is.  This can be overridden though.  See below.
 - Fix Mongolian Variation Selectors for fonts without GDEF.
 - Fix minor invalid buffer access.
 - Accept zh-Hant and zh-Hans language tags.  hb_ot_tag_to_language()

--- a/src/hb-ot-shape-complex-indic.cc
+++ b/src/hb-ot-shape-complex-indic.cc
@@ -692,7 +692,7 @@ initial_reordering_consonant_syllable (const hb_ot_shape_plan_t *plan,
   hb_glyph_info_t *info = buffer->info;
 
   /* https://github.com/behdad/harfbuzz/issues/435#issuecomment-335560167
-   * // For compatibility with legacy useage in Kannada,
+   * // For compatibility with legacy usage in Kannada,
    * // Ra+h+ZWJ must behave like Ra+ZWJ+h...
    */
   if (buffer->props.script == HB_SCRIPT_KANNADA &&

--- a/src/hb-ot-shape-fallback.cc
+++ b/src/hb-ot-shape-fallback.cc
@@ -210,7 +210,7 @@ position_mark (const hb_ot_shape_plan_t *plan,
   pos.x_offset = pos.y_offset = 0;
 
 
-  /* We dont position LEFT and RIGHT marks. */
+  /* We don't position LEFT and RIGHT marks. */
 
   /* X positioning */
   switch (combining_class)


### PR DESCRIPTION
Found using `codespell -i 3 -w -I '../harf-whitelist.txt'`
whereas the whitelist contents were:
```
beng
iff
pres
ot
te
teh
```