### PR TITLE
Fix graphite intergration reordered clusters problem

### DIFF
--- a/src/hb-graphite2.cc
+++ b/src/hb-graphite2.cc
@@ -307,6 +307,8 @@ _hb_graphite2_shape (hb_shape_plan_t    *shape_plan,
     curradv = gr_slot_origin_X(gr_seg_first_slot(seg));
     clusters[0].advance = gr_seg_advance_X(seg) - curradv;
   }
+  else
+    clusters[0].advance = 0;
   for (is = gr_seg_first_slot (seg), ic = 0; is; is = gr_slot_next_in_segment (is), ic++)
   {
     unsigned int before = gr_slot_before (is);
@@ -332,7 +334,10 @@ _hb_graphite2_shape (hb_shape_plan_t    *shape_plan,
       if (HB_DIRECTION_IS_BACKWARD(buffer->props.direction))
         c->advance = curradv - gr_slot_origin_X(is);
       else
-        clusters[ci].advance = gr_slot_origin_X(is) - curradv;
+      {
+        c->advance = 0;
+        clusters[ci].advance += gr_slot_origin_X(is) - curradv;
+      }
       ci++;
       curradv = gr_slot_origin_X(is);
     }
@@ -345,7 +350,7 @@ _hb_graphite2_shape (hb_shape_plan_t    *shape_plan,
   if (HB_DIRECTION_IS_BACKWARD(buffer->props.direction))
     clusters[ci].advance += curradv;
   else
-    clusters[ci].advance = gr_seg_advance_X(seg) - curradv;
+    clusters[ci].advance += gr_seg_advance_X(seg) - curradv;
   ci++;
 
   for (unsigned int i = 0; i < ci; ++i)


### PR DESCRIPTION
This fixes cluster width problems where two clusters merge due to reordering as in the sequence 092A 0930 094D 0915 093E 092A in AnnapurnaSIL.